### PR TITLE
chore(sdk): upgraded .net framework version to v4.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,24 @@ The features that are currently working are the following:
 Requirements
 ------------------------------
 
+### General Pre-requisites
+
+- InnoDB compatible Server such as
+  - [MySQL 5](https://dev.mysql.com/downloads/mysql/5.7.html) or [MariaDB 10](https://mariadb.org/download/)
+- Sufficient Hardware resources for the Emulator.
+  - Recommended: 1GB
+  - Minimum: 256MB
+- Sufficient Storage for the Database.
+  - Recommended: 4GB
+  - Minimum: 100MB
+
 ### Running on Linux/macOS
 
 - [Mono 5](https://www.mono-project.com/download/stable/)
-- [MySQL 5](https://dev.mysql.com/downloads/mysql/5.7.html)
 
 ### Running on Windows
 
 - [.NET 4.6.2 Runtime](https://dotnet.microsoft.com/download/dotnet-framework/thank-you/net462-offline-installer)
-- [MySQL 5](https://dev.mysql.com/downloads/mysql/5.7.html)
 
 ### Building on Linux
 

--- a/README.md
+++ b/README.md
@@ -43,14 +43,32 @@ The features that are currently working are the following:
 
 Requirements
 ------------------------------
-To *run* Melia, you need
-* .NET 4.5 (Mono 4 or above)
-* MySQL 5 compatible database
 
-To *compile* Melia, you need
-* C# 7 compiler, such as:
-  * [Visual Studio](http://www.visualstudio.com/en-us/products/visual-studio-express-vs.aspx) (2017 or later)
-  * [Monodevelop](http://monodevelop.com/) (With Mono version 5 or greater)
+### Running on Linux/macOS
+
+- [Mono 5](https://www.mono-project.com/download/stable/)
+- [MySQL 5](https://dev.mysql.com/downloads/mysql/5.7.html)
+
+### Running on Windows
+
+- [.NET 4.6.2 Runtime](https://dotnet.microsoft.com/download/dotnet-framework/thank-you/net462-offline-installer)
+- [MySQL 5](https://dev.mysql.com/downloads/mysql/5.7.html)
+
+### Building on Linux
+
+- [Mono 5](https://www.mono-project.com/download/stable/)
+- [Mono Develop](https://www.monodevelop.com/download/)
+
+### Building on macOS
+
+- [Mono 5](https://www.mono-project.com/download/stable/)
+- [Mono Develop](https://www.monodevelop.com/download/) or [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/)
+
+
+### Building on Windows
+
+- [.NET 4.6.2 SDK](https://dotnet.microsoft.com/download/dotnet-framework/thank-you/net462-developer-pack-offline-installer)
+- [Visual Studio](https://visualstudio.microsoft.com/downloads/) (Visual Studio 2017 or later) (Community Edition is free)
 
 Installation
 ------------------------------

--- a/src/ChannelServer/ChannelServer.csproj
+++ b/src/ChannelServer/ChannelServer.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Melia.Channel</RootNamespace>
     <AssemblyName>ChannelServer</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/LoginServer/LoginServer.csproj
+++ b/src/LoginServer/LoginServer.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Melia.Login</RootNamespace>
     <AssemblyName>LoginServer</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Melia.Shared</RootNamespace>
     <AssemblyName>Shared</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Test.ChannelServer/Test.ChannelServer.csproj
+++ b/src/Test.ChannelServer/Test.ChannelServer.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Melia.Test.Channel</RootNamespace>
     <AssemblyName>Test.ChannelServer</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Test.Shared/Test.Shared.csproj
+++ b/src/Test.Shared/Test.Shared.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Test.Shared</RootNamespace>
     <AssemblyName>Test.Shared</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/src/WebServer/WebServer.csproj
+++ b/src/WebServer/WebServer.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Melia.Web</RootNamespace>
     <AssemblyName>WebServer</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>


### PR DESCRIPTION
This commit upgrades the .NET Framework version to a stable and supported version (v4.6.2)

Closes #180 