### PR TITLE
Character slot must have a default value

### DIFF
--- a/sql/update-2021-09-14_1.sql
+++ b/sql/update-2021-09-14_1.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `characters` ADD `slot` INT NOT NULL AFTER `level`;
+ALTER TABLE `characters` ADD `slot` INT NOT NULL AFTER `level` DEFAULT '1';


### PR DESCRIPTION
otherwise it causes this error on LoginServer:

[Exception] - MySql.Data.MySqlClient.MySqlException (0x80004005): Field 'slot' doesn't have a default value