### PR TITLE
Fixed World Map Crash

### DIFF
--- a/src/ChannelServer/Network/ChannelPacketSender.cs
+++ b/src/ChannelServer/Network/ChannelPacketSender.cs
@@ -3770,7 +3770,7 @@ namespace Melia.Channel.Network
 		public static void ZC_RESPONSE_FIELD_BOSS_EXIST(ChannelConnection conn)
 		{
 			var packet = new Packet(Op.ZC_RESPONSE_FIELD_BOSS_EXIST);
-			packet.PutInt(1); // 0 usually
+			packet.PutInt(0); // 0 usually
 
 			conn.Send(packet);
 		}


### PR DESCRIPTION
* By default ZC_RESPONSE_FIELD_BOSS_EXIST sends a 0 instead of the 1, otherwise it caused a crash when the world map is opened in-game.
