### PR TITLE
Update web.conf

### DIFF
--- a/system/conf/web.conf
+++ b/system/conf/web.conf
@@ -11,6 +11,6 @@ port: 80
 php_cgi_exe: user/tools/php/php-cgi.exe
 
 // URL to download PHP from if it wasn't found
-php_download: https://windows.php.net/downloads/releases/php-8.2.8-Win32-vs16-x64.zip
+php_download: https://windows.php.net/downloads/releases/php-8.2.8-nts-Win32-vs16-x86.zip
 
 include "/user/conf/web.conf"

--- a/system/conf/web.conf
+++ b/system/conf/web.conf
@@ -11,6 +11,6 @@ port: 80
 php_cgi_exe: user/tools/php/php-cgi.exe
 
 // URL to download PHP from if it wasn't found
-php_download: https://windows.php.net/downloads/releases/php-8.2.7-nts-Win32-vs16-x86.zip
+php_download: https://windows.php.net/downloads/releases/php-8.2.8-Win32-vs16-x64.zip
 
 include "/user/conf/web.conf"


### PR DESCRIPTION
The download link in web.conf doesn't exist, so the server fails with an error.  I updated it to a working link, though I have some concerns about being forced to choose between 32 and 64 bit.