### PR TITLE
Fixed Weight Calculation

### DIFF
--- a/src/ZoneServer/World/Actors/Characters/Components/InventoryComponent.cs
+++ b/src/ZoneServer/World/Actors/Characters/Components/InventoryComponent.cs
@@ -298,7 +298,7 @@ namespace Melia.Zone.World.Actors.Characters.Components
 				this.AddStack(item, addType, false);
 			}
 
-			Send.ZC_OBJECT_PROPERTY(this.Character, "NowWeight");
+			UpdateWeight();
 
 			// Temp fix. The amounts on item stacks that items were added
 			// to are sometimes wrong, a full updates fixes that. Maybe
@@ -563,7 +563,7 @@ namespace Melia.Zone.World.Actors.Characters.Components
 			//Send.ZC_ITEM_INVENTORY_INDEX_LIST(this.Character, item.Data.Category);
 			Send.ZC_ITEM_INVENTORY_DIVISION_LIST(this.Character);
 
-			Send.ZC_OBJECT_PROPERTY(this.Character, "NowWeight", "MSPD");
+			this.UpdateWeight();
 
 			return InventoryResult.Success;
 		}
@@ -597,8 +597,7 @@ namespace Melia.Zone.World.Actors.Characters.Components
 
 				Send.ZC_ITEM_REMOVE(this.Character, item.ObjectId, amount, msg, InventoryType.Inventory);
 
-				this.Character.Properties.Invalidate(PropertyName.NowWeight);
-				Send.ZC_OBJECT_PROPERTY(this.Character, PropertyName.NowWeight);
+				this.UpdateWeight();
 			}
 
 			ZoneServer.Instance.ServerEvents.OnPlayerRemovedItem(this.Character, item.Id, amountRemoved);
@@ -650,7 +649,7 @@ namespace Melia.Zone.World.Actors.Characters.Components
 
 			if (amountRemoved != 0)
 			{
-				Send.ZC_OBJECT_PROPERTY(this.Character, "NowWeight");
+				this.UpdateWeight();
 				ZoneServer.Instance.ServerEvents.OnPlayerRemovedItem(this.Character, itemId, amountRemoved);
 			}
 
@@ -746,6 +745,20 @@ namespace Melia.Zone.World.Actors.Characters.Components
 		}
 
 		/// <summary>
+		/// Calculate the current weight and updates the client.
+		/// </summary>
+		private void UpdateWeight()
+		{
+			var prevMSPD = this.Character.Properties.GetFloat(PropertyName.MSPD);
+			this.Character.Properties.Invalidate(PropertyName.NowWeight, PropertyName.MSPD);
+			Send.ZC_OBJECT_PROPERTY(this.Character, PropertyName.NowWeight, PropertyName.MSPD);
+
+			var currentMSPD = this.Character.Properties.GetFloat(PropertyName.MSPD);
+			if (prevMSPD != currentMSPD)
+				Send.ZC_MOVE_SPEED(this.Character);
+		}
+
+		/// <summary>
 		/// Returns combined weight of all items in the inventory.
 		/// </summary>
 		/// <returns></returns>
@@ -756,8 +769,8 @@ namespace Melia.Zone.World.Actors.Characters.Components
 			// TODO: Cache.
 			lock (_syncLock)
 			{
-				result += _items.SelectMany(a => a.Value).Sum(a => a.Data.Weight);
-				result += _equip.Values.Where(a => !(a is DummyEquipItem)).Sum(a => a.Data.Weight);
+				result += _items.SelectMany(a => a.Value).Sum(a => a.Amount * a.Data.Weight);
+				result += _equip.Values.Where(a => !(a is DummyEquipItem)).Sum(a => a.Amount * a.Data.Weight);
 			}
 
 			return result;
@@ -817,7 +830,7 @@ namespace Melia.Zone.World.Actors.Characters.Components
 			Send.ZC_ITEM_INVENTORY_DIVISION_LIST(this.Character);
 
 			// Update weight
-			Send.ZC_OBJECT_PROPERTY(this.Character, "NowWeight");
+			this.UpdateWeight();
 
 			return InventoryResult.Success;
 		}

--- a/system/scripts/zone/core/calc_character.cs
+++ b/system/scripts/zone/core/calc_character.cs
@@ -14,6 +14,7 @@ using Melia.Zone.Scripting;
 using Melia.Zone.World.Actors.Characters;
 using Melia.Zone.World.Actors.Characters.Components;
 using Melia.Zone.World.Actors.CombatEntities.Components;
+using Yggdrasil.Logging;
 using Yggdrasil.Util;
 
 public class CharacterCalculationsScript : GeneralScript
@@ -1318,8 +1319,15 @@ public class CharacterCalculationsScript : GeneralScript
 		var baseValue = 30;
 		var byBuff = properties.GetFloat(PropertyName.MSPD_BM);
 		var byBonus = properties.GetFloat(PropertyName.MSPD_Bonus);
+		var value = (baseValue + byBuff + byBonus);
 
-		return (baseValue + byBuff + byBonus);
+		var nowWeight = properties.GetFloat(PropertyName.NowWeight);
+		var maxWeight = properties.GetFloat(PropertyName.MaxWeight);
+
+		if (nowWeight > maxWeight)
+			value /= 3;
+
+		return value;
 	}
 
 	/// <summary>


### PR DESCRIPTION
Fixes #257 
* Item weight wasn't always recalculated.
* Item weight wasn't multiplied by the amount.
* The side effect of being overweight wasn't implemented; now, movement speed is reduced by 3 times when overweight.