### PR TITLE
Block and critical formulas implementation

### DIFF
--- a/src/Shared/Game/Const/HitResultType.cs
+++ b/src/Shared/Game/Const/HitResultType.cs
@@ -14,7 +14,7 @@
 		/// <summary>
 		/// Displays damage in blue.
 		/// </summary>
-		Unk2 = 2,
+		Block = 2,
 
 		/// <summary>
 		/// Normal hit.

--- a/src/ZoneServer/World/Actors/Monsters/MonsterProperties.cs
+++ b/src/ZoneServer/World/Actors/Monsters/MonsterProperties.cs
@@ -59,6 +59,11 @@ namespace Melia.Zone.World.Actors.Monsters
 			this.Create(new CFloatProperty(PropertyName.HR, () => this.CalculateProperty("SCR_Get_MON_HR")));
 			this.Create(new CFloatProperty(PropertyName.SR, () => this.CalculateProperty("SCR_Get_MON_SR")));
 			this.Create(new CFloatProperty(PropertyName.SDR, () => this.CalculateProperty("SCR_Get_MON_SDR")));
+			this.Create(new CFloatProperty(PropertyName.CRTHR, () => this.CalculateProperty("SCR_Get_MON_CRTHR")));
+			this.Create(new CFloatProperty(PropertyName.CRTDR, () => this.CalculateProperty("SCR_Get_MON_CRTDR")));
+			this.Create(new CFloatProperty(PropertyName.CRTATK, () => this.CalculateProperty("SCR_Get_MON_CRTATK")));
+			this.Create(new CFloatProperty(PropertyName.BLK, () => this.CalculateProperty("SCR_Get_MON_BLK")));
+			this.Create(new CFloatProperty(PropertyName.BLK_BREAK, () => this.CalculateProperty("SCR_Get_MON_BLK_BREAK")));
 
 			this.Create(new FloatProperty(PropertyName.WlkMSPD, this.Monster.Data.WalkSpeed));
 			this.Create(new FloatProperty(PropertyName.RunMSPD, this.Monster.Data.RunSpeed));

--- a/system/scripts/zone/core/calc_character.cs
+++ b/system/scripts/zone/core/calc_character.cs
@@ -1063,14 +1063,14 @@ public class CharacterCalculationsScript : GeneralScript
 		var stat = properties.GetFloat(PropertyName.DEX);
 
 		var byStat = (stat * 4f) + ((float)Math.Floor(stat / 10f) * 10f);
-		var byItem = 0; // TODO
+		var byItem = 0f;
+
+		byItem += character.Inventory.GetEquipProperties(PropertyName.CRTATK);
 
 		var value = byStat + byItem;
 
-		// Buffs: "CRTATK_BM"
-		var byBuffs = 0;
+		var byBuffs = properties.GetFloat(PropertyName.CRTATK_BM);
 
-		// Rate buffs: Does the game have something like CritATK +x%?
 		var rate = 0;
 		var byRateBuffs = (float)Math.Floor(value * rate);
 
@@ -1092,7 +1092,9 @@ public class CharacterCalculationsScript : GeneralScript
 		var level = properties.GetFloat(PropertyName.Lv);
 
 		var byLevel = level / 2f;
-		var byItem = 0; // TODO
+		var byItem = 0f;
+
+		byItem += character.Inventory.GetEquipProperties(PropertyName.CRTHR);
 
 		var value = byLevel + byItem;
 
@@ -1119,7 +1121,9 @@ public class CharacterCalculationsScript : GeneralScript
 		var level = properties.GetFloat(PropertyName.Lv);
 
 		var byLevel = level / 2f;
-		var byItem = 0; // TODO
+		var byItem = 0f;
+
+		byItem += character.Inventory.GetEquipProperties(PropertyName.CRTDR);
 
 		var value = byLevel + byItem;
 
@@ -1148,8 +1152,10 @@ public class CharacterCalculationsScript : GeneralScript
 
 		var byLevel = level / 4f;
 		var byStat = (stat / 2f) + ((float)Math.Floor(stat / 15f) * 3f);
-		var byItem = 0; // HR, ADD_HR
+		var byItem = 0f;
 
+		byItem += character.Inventory.GetEquipProperties(PropertyName.HR);
+		byItem += character.Inventory.GetEquipProperties(PropertyName.ADD_HR);
 		var value = byLevel + byStat + byItem;
 
 		var byBuffs = character.Properties.GetFloat(PropertyName.HR_BM);
@@ -1177,7 +1183,10 @@ public class CharacterCalculationsScript : GeneralScript
 
 		var byLevel = level / 4f;
 		var byStat = (stat / 2f) + ((float)Math.Floor(stat / 15f) * 3f);
-		var byItem = 0; // TODO
+		var byItem = 0f;
+
+		byItem += character.Inventory.GetEquipProperties(PropertyName.DR);
+		byItem += character.Inventory.GetEquipProperties(PropertyName.ADD_DR);
 
 		var value = byLevel + byStat + byItem;
 
@@ -1211,9 +1220,16 @@ public class CharacterCalculationsScript : GeneralScript
 
 		var byLevel = Level / 4f;
 		var byStat = (stat / 2f) + ((float)Math.Floor(stat / 15f) * 3f);
-		var byItem = 0f; // TODO
+		var byItem = 0f;
+
+		byItem += character.Inventory.GetEquipProperties(PropertyName.BLK);
 
 		var value = byLevel + byStat + byItem;
+
+		// The 'Increases final block rate by x%' on shields
+		var byItemBlockRate = character.Inventory.GetEquipProperties(PropertyName.BlockRate);
+		byItemBlockRate = (float)Math.Floor(value * (byItemBlockRate * 0.01f));
+		value += byItemBlockRate;
 
 		var byBuffs = character.Properties.GetFloat(PropertyName.BLK_BM);
 
@@ -1240,7 +1256,9 @@ public class CharacterCalculationsScript : GeneralScript
 
 		var byLevel = level / 4f;
 		var byStat = (stat / 2f) + ((float)Math.Floor(stat / 15f) * 3f);
-		var byItem = 0; // TODO
+		var byItem = 0f;
+
+		byItem += character.Inventory.GetEquipProperties(PropertyName.BLK_BREAK);
 
 		var value = byLevel + byStat + byItem;
 

--- a/system/scripts/zone/core/calc_combat.cs
+++ b/system/scripts/zone/core/calc_combat.cs
@@ -89,12 +89,12 @@ public class CombatCalculationsScript : GeneralScript
 		damage *= skillFactor / 100f;
 		damage += skillAtkAdd;
 
+		// Block needs to be calculated before criticals happen,
+		// but the damage must be reduced after defense reductions and modifiers
 		var blockChance = SCR_GetBlockChance(attacker, target, skill, skillHitResult);
 		if (rnd.Next(100) < blockChance)
 		{
 			skillHitResult.Result = HitResultType.Block;
-			// Block needs to be calculated before criticals happen,
-			// but the damage must be reduced after defense reductions and modifiers
 		}
 
 		var crtChance = SCR_GetCritChance(attacker, target, skill, skillHitResult);
@@ -160,9 +160,13 @@ public class CombatCalculationsScript : GeneralScript
 			skillHitResult.HitCount = (int)Math.Round(skillHitResult.HitCount * hitCountMultiplier);
 		}
 
-		// Blocked
+		// Block damage reduction
 		if (skillHitResult.Result == HitResultType.Block)
-			damage /= 2;
+			damage /= 2f;
+
+		// Critical damage bonus
+		if (skillHitResult.Result == HitResultType.Crit)
+			damage *= 1.5f;
 
 		return (int)damage;
 	}

--- a/system/scripts/zone/core/calc_combat.cs
+++ b/system/scripts/zone/core/calc_combat.cs
@@ -65,6 +65,8 @@ public class CombatCalculationsScript : GeneralScript
 	{
 		var SCR_GetRandomAtk = ScriptableFunctions.Combat.Get("SCR_GetRandomAtk");
 		var SCR_GetDodgeChance = ScriptableFunctions.Combat.Get("SCR_GetDodgeChance");
+		var SCR_GetBlockChance = ScriptableFunctions.Combat.Get("SCR_GetBlockChance");
+		var SCR_GetCritChance = ScriptableFunctions.Combat.Get("SCR_GetCritChance");
 		var SCR_HitCountMultiplier = ScriptableFunctions.Combat.Get("SCR_HitCountMultiplier");
 		var SCR_SizeTypeBonus = ScriptableFunctions.Combat.Get("SCR_SizeTypeBonus");
 		var SCR_AttributeMultiplier = ScriptableFunctions.Combat.Get("SCR_AttributeMultiplier");
@@ -87,8 +89,16 @@ public class CombatCalculationsScript : GeneralScript
 		damage *= skillFactor / 100f;
 		damage += skillAtkAdd;
 
-		var crtHr = attacker.Properties.GetFloat(PropertyName.CRTHR);
-		if (rnd.Next(1000) < crtHr)
+		var blockChance = SCR_GetBlockChance(attacker, target, skill, skillHitResult);
+		if (rnd.Next(100) < blockChance)
+		{
+			skillHitResult.Result = HitResultType.Block;
+			// Block needs to be calculated before criticals happen,
+			// but the damage must be reduced after defense reductions and modifiers
+		}
+
+		var crtChance = SCR_GetCritChance(attacker, target, skill, skillHitResult);
+		if (rnd.Next(100) < crtChance && skillHitResult.Result != HitResultType.Block)
 		{
 			var crtAtk = attacker.Properties.GetFloat(PropertyName.CRTATK);
 			damage += crtAtk;
@@ -149,6 +159,10 @@ public class CombatCalculationsScript : GeneralScript
 			damage *= hitCountMultiplier;
 			skillHitResult.HitCount = (int)Math.Round(skillHitResult.HitCount * hitCountMultiplier);
 		}
+
+		// Blocked
+		if (skillHitResult.Result == HitResultType.Block)
+			damage /= 2;
 
 		return (int)damage;
 	}
@@ -508,5 +522,51 @@ public class CombatCalculationsScript : GeneralScript
 		var dodgeChance = Math2.Clamp(0, 80, Math.Pow(Math.Max(0, dr - hr), 0.65f));
 
 		return (float)dodgeChance;
+	}
+
+	/// <summary>
+	/// Returns the chance for the target to block a hit from the attacker.
+	/// </summary>
+	/// <param name="attacker"></param>
+	/// <param name="target"></param>
+	/// <param name="skill"></param>
+	/// <param name="skillHitResult"></param>
+	/// <returns></returns>
+	[ScriptableFunction]
+	public float SCR_GetBlockChance(ICombatEntity attacker, ICombatEntity target, Skill skill, SkillHitResult skillHitResult)
+	{
+		if (skill.Data.AttackType == SkillAttackType.Magic)
+			return 0;
+		
+		var block = target.Properties.GetFloat(PropertyName.BLK);
+		var blockBreak = attacker.Properties.GetFloat(PropertyName.BLK_BREAK);
+
+		// Based on: https://treeofsavior.com/page/news/view.php?n=951​
+		var blockChance = Math2.Clamp(0, 90, Math.Pow(Math.Max(0, Math.Max(0, block - blockBreak)), 0.7f));
+		
+		return (float)blockChance;
+	}
+
+	/// <summary>
+	/// Returns the chance for the target to take a critical hit from the attacker.
+	/// </summary>
+	/// <param name="attacker"></param>
+	/// <param name="target"></param>
+	/// <param name="skill"></param>
+	/// <param name="skillHitResult"></param>
+	/// <returns></returns>
+	[ScriptableFunction]
+	public float SCR_GetCritChance(ICombatEntity attacker, ICombatEntity target, Skill skill, SkillHitResult skillHitResult)
+	{
+		if (skill.Data.AttackType == SkillAttackType.Magic)
+			return 0;
+		
+		var critDodgeRate = target.Properties.GetFloat(PropertyName.CRTDR);
+		var critHitRate = attacker.Properties.GetFloat(PropertyName.CRTHR);
+
+		// Based on: https://treeofsavior.com/page/news/view.php?n=951​
+		var blockChance = Math2.Clamp(0, 100, Math.Pow(Math.Max(0, Math.Max(0, critHitRate - critDodgeRate)), 0.6f));
+		
+		return (float)blockChance;
 	}
 }

--- a/system/scripts/zone/core/calc_monster.cs
+++ b/system/scripts/zone/core/calc_monster.cs
@@ -334,4 +334,140 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 
 		return (int)Math.Max(1, value);
 	}
+
+	/// <summary>
+	/// Returns the monster's Critical Hit Rate.
+	/// </summary>
+	/// <param name="monster"></param>
+	/// <returns></returns>
+	[ScriptableFunction]
+	public float SCR_Get_MON_CRTHR(Mob monster)
+	{
+		if (monster.Properties.Overrides.TryGetFloat(PropertyName.CRTHR, out var fixValue))
+			return fixValue;
+		
+		var value = (float)monster.Data.CritHitRate;
+		
+		var byBuffs = 0f;
+		byBuffs += monster.Properties.GetFloat(PropertyName.CRTHR_BM, 0);
+		
+		var byRateBuffs = 0f;
+		byRateBuffs += monster.Properties.GetFloat(PropertyName.CRTHR_RATE_BM);
+		byRateBuffs = value * byRateBuffs;
+		
+		value = value + byBuffs + byRateBuffs;
+		
+		return (int)Math.Max(0, value);
+	}
+	
+	/// <summary>
+	/// Returns the monster's Critical Dodge Rate (Critical resistance).
+	/// </summary>
+	/// <param name="monster"></param>
+	/// <returns></returns>
+	[ScriptableFunction]
+	public float SCR_Get_MON_CRTDR(Mob monster)
+	{
+		if (monster.Properties.Overrides.TryGetFloat(PropertyName.CRTDR, out var fixValue))
+			return fixValue;
+		
+		var value = (float)monster.Data.CritDodgeRate;
+		
+		var byBuffs = 0f;
+		byBuffs += monster.Properties.GetFloat(PropertyName.CRTDR_BM, 0);
+		
+		var byRateBuffs = 0f;
+		byRateBuffs += monster.Properties.GetFloat(PropertyName.CRTDR_RATE_BM);
+		byRateBuffs = value * byRateBuffs;
+		
+		value = value + byBuffs + byRateBuffs;
+		
+		var decRatio = monster.Properties.GetFloat(PropertyName.CRTDR_RATE_MUL_BM, 1);
+		
+		if (decRatio < 0.5f)
+			decRatio = 0.5f;
+		
+		value *= decRatio;
+		
+		return (int)Math.Max(0, value);
+	}
+
+	/// <summary>
+	/// Returns the monster's Critical Attack.
+	/// </summary>
+	/// <param name="monster"></param>
+	/// <returns></returns>
+	[ScriptableFunction]
+	public float SCR_Get_MON_CRTATK(Mob monster)
+	{
+		if (monster.Properties.Overrides.TryGetFloat(PropertyName.CRTATK, out var fixValue))
+			return fixValue;
+
+		var value = (float)monster.Data.CritAttack;
+		
+		var byBuffs = 0f;
+		byBuffs += monster.Properties.GetFloat(PropertyName.CRTATK_BM, 0);
+		
+		var byRateBuffs = 0f;
+		//byRateBuffs += monster.Properties.GetFloat(PropertyName.CRTATK_RATE_BM);
+		byRateBuffs = value * byRateBuffs;
+		
+		value = value + byBuffs + byRateBuffs;
+		
+		return (int)Math.Max(0, value);
+	}
+
+	/// <summary>
+	/// Returns the monster's block rate.
+	/// </summary>
+	/// <param name="monster"></param>
+	/// <returns></returns>
+	[ScriptableFunction]
+	public float SCR_Get_MON_BLK(Mob monster)
+	{
+		if (monster.Properties.Overrides.TryGetFloat(PropertyName.BLK, out var fixValue))
+			return fixValue;
+		
+		var properties = monster.Properties;
+		
+		var baseValue = (float)monster.Data.BlockRate;
+		var value = baseValue;
+		
+		var byBuffs = properties.GetFloat(PropertyName.BLK_BM);
+		
+		var byRateBuffs = 0f;
+		byRateBuffs += properties.GetFloat(PropertyName.BLK_RATE_BM);
+		byRateBuffs = (value * byRateBuffs);
+		
+		value += byBuffs + byRateBuffs;
+		
+		return value;
+	}
+	
+	/// <summary>
+	/// Returns the monster's block break (penetration).
+	/// </summary>
+	/// <param name="monster"></param>
+	/// <returns></returns>
+	[ScriptableFunction]
+	public float SCR_Get_MON_BLK_BREAK(Mob monster)
+	{
+		if (monster.Properties.Overrides.TryGetFloat(PropertyName.BLK_BREAK, out var fixValue))
+			return fixValue;
+		
+		var properties = monster.Properties;
+		
+		var baseValue = (float)monster.Data.BlockBreakRate;
+		var value = baseValue;
+		
+		var byBuffs = properties.GetFloat(PropertyName.BLK_BREAK_BM);
+		
+		var byRateBuffs = 0f;
+		byRateBuffs += properties.GetFloat(PropertyName.BLK_BREAK_RATE_BM);
+		byRateBuffs = (value * byRateBuffs);
+		
+		value += byBuffs + byRateBuffs;
+		
+		return value;
+	}
 }

--- a/system/scripts/zone/core/calc_monster.cs
+++ b/system/scripts/zone/core/calc_monster.cs
@@ -357,7 +357,7 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 		
 		value = value + byBuffs + byRateBuffs;
 		
-		return (int)Math.Max(0, value);
+		return (int)value;
 	}
 	
 	/// <summary>
@@ -389,7 +389,7 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 		
 		value *= decRatio;
 		
-		return (int)Math.Max(0, value);
+		return (int)value;
 	}
 
 	/// <summary>
@@ -408,13 +408,9 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 		var byBuffs = 0f;
 		byBuffs += monster.Properties.GetFloat(PropertyName.CRTATK_BM, 0);
 		
-		var byRateBuffs = 0f;
-		//byRateBuffs += monster.Properties.GetFloat(PropertyName.CRTATK_RATE_BM);
-		byRateBuffs = value * byRateBuffs;
+		value += byBuffs;
 		
-		value = value + byBuffs + byRateBuffs;
-		
-		return (int)Math.Max(0, value);
+		return (int)value;
 	}
 
 	/// <summary>
@@ -434,14 +430,10 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 		var value = baseValue;
 		
 		var byBuffs = properties.GetFloat(PropertyName.BLK_BM);
+
+		value += byBuffs;
 		
-		var byRateBuffs = 0f;
-		byRateBuffs += properties.GetFloat(PropertyName.BLK_RATE_BM);
-		byRateBuffs = (value * byRateBuffs);
-		
-		value += byBuffs + byRateBuffs;
-		
-		return value;
+		return (int)value;
 	}
 	
 	/// <summary>
@@ -462,12 +454,8 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 		
 		var byBuffs = properties.GetFloat(PropertyName.BLK_BREAK_BM);
 		
-		var byRateBuffs = 0f;
-		byRateBuffs += properties.GetFloat(PropertyName.BLK_BREAK_RATE_BM);
-		byRateBuffs = (value * byRateBuffs);
+		value += byBuffs;
 		
-		value += byBuffs + byRateBuffs;
-		
-		return value;
+		return (int)value;
 	}
 }


### PR DESCRIPTION
This PR implements:

- [NEW] Block Rate
- [NEW] Block Penetration
- Block Chance Formula
- Block damage reduction (50% less damage)
- [NEW] Critical Defense Rate
- Improved Critical Chance Formula
- Improved Critical Damage to deal 1.5x damage
- Adds Block/BlockPen and Critical Attack/Rate/Defense stats for monsters

This PR *DOES NOT* implement:

- Active blocking (holding 'C' to block)
- Equipment block rates in items.txt database

Videos:

- Player blocking attacks: https://www.youtube.com/watch?v=tGhd0X7mmpM
- Monster blocking attacks: https://www.youtube.com/watch?v=IcUwUen4OZA

Based on: https://treeofsavior.com/page/news/view.php?n=951
Credits to @SalmanTKhan for base implementation