### PR TITLE
Doppelsoeldner Tier 1

### DIFF
--- a/src/ZoneServer/Buffs/Handlers/Common_Shock.cs
+++ b/src/ZoneServer/Buffs/Handlers/Common_Shock.cs
@@ -1,0 +1,61 @@
+﻿using Melia.Zone.Buffs.Base;
+using Melia.Zone.World;
+using Melia.Shared.Game.Const;
+using System;
+using Melia.Zone.Network;
+
+namespace Melia.Zone.Buffs.Handlers
+{
+	/// <summary>
+	/// Handler for Common_Slow, which affects the movement speed on use.
+	/// </summary>
+	[BuffHandler(BuffId.Common_Shock)]
+	public class Common_Shock : BuffHandler
+	{
+		private const float IntDebuffRate = 0.1f;
+		private const float SprDebuffRate = 0.1f;
+		private const string ReduceIntName = "Melia.ReduceInt";
+		private const string ReduceSprName = "Melia.ReduceSpr";
+
+		/// <summary>
+		/// Starts buff, reducing Int and Spr
+		/// </summary>
+		/// <param name="buff"></param>
+		public override void OnStart(Buff buff)
+		{
+			var target = buff.Target;
+			var caster = buff.Caster;
+
+			var reduceInt = target.Properties.GetFloat(PropertyName.INT) * IntDebuffRate;
+			buff.Vars.SetFloat(ReduceIntName, -reduceInt);
+
+			target.Properties.Modify(PropertyName.INT_BM, -reduceInt);
+
+			var reduceSpr = target.Properties.GetFloat(PropertyName.MNA) * SprDebuffRate;
+			buff.Vars.SetFloat(ReduceSprName, -reduceSpr);
+
+			target.Properties.Modify(PropertyName.MNA_BM, -reduceSpr);
+		}
+
+		/// <summary>
+		/// Ends the buff, resetting the Int and Spr
+		/// </summary>
+		/// <param name="buff"></param>
+		public override void OnEnd(Buff buff)
+		{
+			if (buff.Vars.TryGetFloat(ReduceIntName, out var reduceInt))
+			{
+				var target = buff.Target;
+
+				target.Properties.Modify(PropertyName.INT_BM, reduceInt);
+			}
+
+			if (buff.Vars.TryGetFloat(ReduceSprName, out var reduceSpr))
+			{
+				var target = buff.Target;
+
+				target.Properties.Modify(PropertyName.MNA_BM, reduceSpr);
+			}
+		}
+	}
+}

--- a/src/ZoneServer/Buffs/Handlers/Swordsman/Doppelsoeldner/DoublePayEarn.cs
+++ b/src/ZoneServer/Buffs/Handlers/Swordsman/Doppelsoeldner/DoublePayEarn.cs
@@ -1,0 +1,35 @@
+﻿using Melia.Shared.Game.Const;
+using Melia.Zone.Buffs.Base;
+
+namespace Melia.Zone.Buffs.Handlers.Swordsman.Doppelsoeldner
+{
+	/// <summary>
+	/// Handle for the Bear Buff, which increases the target's defense.
+	/// </summary>
+	[BuffHandler(BuffId.Double_pay_earn_Buff)]
+	public class DoublePayEarn : BuffHandler
+	{
+		private const string VarName = "Melia.LootingChanceBonus";
+		private const float LootingChanceBonusPerLevel = 30f; // 30 looting chance is 3% drop rate bonus
+
+		public override void OnStart(Buff buff)
+		{
+			var bonus = this.GetLootingChanceBonus(buff);
+			buff.Vars.SetFloat(VarName, bonus);
+
+			buff.Target.Properties.Modify(PropertyName.LootingChance_BM, bonus);
+		}
+
+		public override void OnEnd(Buff buff)
+		{
+			if (buff.Vars.TryGetFloat(VarName, out var bonus))
+				buff.Target.Properties.Modify(PropertyName.LootingChance_BM, -bonus);
+		}
+
+		private float GetLootingChanceBonus(Buff buff)
+		{
+			var skillLevel = buff.NumArg1;
+			return skillLevel * LootingChanceBonusPerLevel;
+		}
+	}
+}

--- a/src/ZoneServer/Database/ZoneDb.cs
+++ b/src/ZoneServer/Database/ZoneDb.cs
@@ -18,7 +18,7 @@ using Melia.Zone.World.Actors.CombatEntities.Components;
 using Melia.Zone.World.Items;
 using Melia.Zone.World.Maps;
 using Melia.Zone.World.Quests;
-using MySqlConnector;
+using MySql.Data.MySqlClient;
 using Yggdrasil.Logging;
 using Yggdrasil.Util;
 
@@ -825,7 +825,7 @@ namespace Melia.Zone.Database
 		private void LoadChatMacros(Account account)
 		{
 			using (var conn = this.GetConnection())
-			using (var mc = new MySqlCommand("SELECT * FROM `chatmacros` WHERE `accountId` = @accountId ORDER BY `index` DESC", conn))
+			using (var mc = new MySqlCommand("SELECT * FROM `chatMacros` WHERE `accountId` = @accountId ORDER BY `index` DESC", conn))
 			{
 				mc.Parameters.AddWithValue("@accountId", account.Id);
 
@@ -853,7 +853,7 @@ namespace Melia.Zone.Database
 			using (var conn = this.GetConnection())
 			using (var trans = conn.BeginTransaction())
 			{
-				using (var mc = new MySqlCommand("DELETE FROM `chatmacros` WHERE `accountId` = @accountId", conn, trans))
+				using (var mc = new MySqlCommand("DELETE FROM `chatMacros` WHERE `accountId` = @accountId", conn, trans))
 				{
 					mc.Parameters.AddWithValue("@accountId", account.Id);
 					mc.ExecuteNonQuery();
@@ -861,7 +861,7 @@ namespace Melia.Zone.Database
 
 				foreach (var macro in account.GetChatMacros().OrderBy(x => x.Index))
 				{
-					using (var cmd = new InsertCommand("INSERT INTO `chatmacros` {0}", conn, trans))
+					using (var cmd = new InsertCommand("INSERT INTO `chatMacros` {0}", conn, trans))
 					{
 						cmd.Set("accountId", account.Id);
 						cmd.Set("index", macro.Index);
@@ -883,7 +883,7 @@ namespace Melia.Zone.Database
 		private void LoadRevealedMaps(Account account)
 		{
 			using (var conn = this.GetConnection())
-			using (var mc = new MySqlCommand("SELECT * FROM `revealedmaps` WHERE `accountId` = @accountId", conn))
+			using (var mc = new MySqlCommand("SELECT * FROM `revealedMaps` WHERE `accountId` = @accountId", conn))
 			{
 				mc.Parameters.AddWithValue("@accountId", account.Id);
 
@@ -911,7 +911,7 @@ namespace Melia.Zone.Database
 			using (var conn = this.GetConnection())
 			using (var trans = conn.BeginTransaction())
 			{
-				using (var mc = new MySqlCommand("DELETE FROM `revealedmaps` WHERE `accountId` = @accountId", conn, trans))
+				using (var mc = new MySqlCommand("DELETE FROM `revealedMaps` WHERE `accountId` = @accountId", conn, trans))
 				{
 					mc.Parameters.AddWithValue("@accountId", account.Id);
 					mc.ExecuteNonQuery();
@@ -919,7 +919,7 @@ namespace Melia.Zone.Database
 
 				foreach (var revealedMap in account.GetRevealedMaps())
 				{
-					using (var cmd = new InsertCommand("INSERT INTO `revealedmaps` {0}", conn, trans))
+					using (var cmd = new InsertCommand("INSERT INTO `revealedMaps` {0}", conn, trans))
 					{
 						cmd.Set("accountId", account.Id);
 						cmd.Set("map", revealedMap.MapId);

--- a/src/ZoneServer/Database/ZoneDb.cs
+++ b/src/ZoneServer/Database/ZoneDb.cs
@@ -18,7 +18,7 @@ using Melia.Zone.World.Actors.CombatEntities.Components;
 using Melia.Zone.World.Items;
 using Melia.Zone.World.Maps;
 using Melia.Zone.World.Quests;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Yggdrasil.Logging;
 using Yggdrasil.Util;
 

--- a/src/ZoneServer/Scripting/ScriptableFunctions.cs
+++ b/src/ZoneServer/Scripting/ScriptableFunctions.cs
@@ -141,7 +141,7 @@ namespace Melia.Zone.Scripting
 	/// <param name="skill"></param>
 	/// <param name="skillHitResult"></param>
 	/// <returns></returns>
-	public delegate float CombatCalcFunction(ICombatEntity attacker, ICombatEntity target, Skill skill, SkillHitResult skillHitResult);
+	public delegate float CombatCalcFunction(ICombatEntity attacker, ICombatEntity target, Skill skill, SkillModifier modifier, SkillHitResult skillHitResult);
 
 	/// <summary>
 	/// A function that determines the result of a skill hitting a target.
@@ -150,7 +150,7 @@ namespace Melia.Zone.Scripting
 	/// <param name="target"></param>
 	/// <param name="skill"></param>
 	/// <returns></returns>
-	public delegate SkillHitResult SkillHitFunction(ICombatEntity attacker, ICombatEntity target, Skill skill);
+	public delegate SkillHitResult SkillHitFunction(ICombatEntity attacker, ICombatEntity target, Skill skill, SkillModifier modifier);
 
 	/// <summary>
 	/// A function that determines whether an ability can be learned.

--- a/src/ZoneServer/Skills/Combat/SkillModifier.cs
+++ b/src/ZoneServer/Skills/Combat/SkillModifier.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Melia.Shared.Game.Const;
+
+namespace Melia.Zone.Skills.Combat
+{
+	/// <summary>
+	/// A class for properties that can modify the damage calculation for a skill
+	/// </summary>
+	public class SkillModifier
+	{
+		/// <summary>
+		/// Adds extra PAtk to the damage calculation
+		/// </summary>
+		public float BonusPAtk { get; set; }
+
+		/// <summary>
+		/// Adds extra MAtk to the damage calculation
+		/// </summary>
+		public float BonusMAtk { get; set; }
+
+		/// <summary>
+		/// Adds extra (flat) damage to the damage calculation
+		/// </summary>
+		public float BonusDamage { get; set; }
+
+		/// <summary>
+		/// Ignores a certain percentage of target's PDef and MDef
+		/// 0.1 = ignore 10% defense
+		/// </summary>
+		public float IgnoreDefPercent { get; set; }
+
+		/// <summary>
+		/// Multiplies the attack damage before enemy defense is applied
+		/// This is a percentage with 1.00 as the base, so 1.02 adds 2% damage
+		/// </summary>
+		public float DamageMultiplier { get; set; }
+
+		/// <summary>
+		/// The number of hits the skill does
+		/// This also multiplies the damage by this amount
+		/// </summary>
+		public int HitCount { get; set; }
+
+		/// <summary>
+		/// Creates new skill modifier.
+		/// </summary>
+		public SkillModifier()
+		{
+			this.DamageMultiplier = 1.0f;
+			this.HitCount = 1;
+		}
+	}
+}

--- a/src/ZoneServer/Skills/Handlers/Common/MeleeGround.cs
+++ b/src/ZoneServer/Skills/Handlers/Common/MeleeGround.cs
@@ -16,7 +16,7 @@ namespace Melia.Zone.Skills.Handlers.Common
 	/// <summary>
 	/// Handles melee skills targeting the ground in front of the caster.
 	/// </summary>
-	[SkillHandler(SkillId.Normal_Attack, SkillId.Hammer_Attack, SkillId.Common_DaggerAries)]
+	[SkillHandler(SkillId.Normal_Attack, SkillId.Normal_Attack_TH, SkillId.Hammer_Attack, SkillId.Common_DaggerAries)]
 	public class MeleeGroundSkillHandler : IMeleeGroundSkillHandler
 	{
 		/// <summary>

--- a/src/ZoneServer/Skills/Handlers/Swordsman/Doppelsoeldner/DeedsOfValor.cs
+++ b/src/ZoneServer/Skills/Handlers/Swordsman/Doppelsoeldner/DeedsOfValor.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Melia.Shared.L10N;
+using Melia.Shared.Game.Const;
+using Melia.Shared.World;
+using Melia.Zone.Network;
+using Melia.Zone.Skills.Handlers.Base;
+using Melia.Zone.World.Actors;
+using Melia.Zone.World.Actors.CombatEntities.Components;
+
+namespace Melia.Zone.Skills.Handlers.Swordsman.Doppelsoeldner
+{
+	/// <summary>
+	/// Handler for the Doppelsoeldner skill Deeds of Valor.
+	/// </summary>
+	[SkillHandler(SkillId.Doppelsoeldner_DeedsOfValor)]
+	public class DeedsOfValor : ISelfSkillHandler
+	{
+		public const float baseDamageMultiplier = 1.15f;  // 15% damage bonus
+		public const float damageMultiplierPerLevel = 0.01f;  // 1% damage bonus per level
+
+		/// <summary>
+		/// Handles skill, applying the buff to the caster.
+		/// </summary>
+		/// <param name="skill"></param>
+		/// <param name="caster"></param>
+		/// <param name="originPos"></param>
+		/// <param name="dir"></param>
+		public void Handle(Skill skill, ICombatEntity caster, Position originPos, Direction dir)
+		{
+			if (!caster.TrySpendSp(skill))
+			{
+				caster.ServerMessage(Localization.Get("Not enough SP."));
+				return;
+			}
+
+			skill.IncreaseOverheat();
+			caster.SetAttackState(true);
+
+			var target = caster;
+
+			var duration = TimeSpan.FromMinutes(30);
+			target.StartBuff(BuffId.DeedsOfValor, skill.Level, baseDamageMultiplier + damageMultiplierPerLevel * skill.Level, duration, caster);
+
+			Send.ZC_SKILL_MELEE_TARGET(caster, skill, target, null);
+		}
+	}
+}

--- a/src/ZoneServer/Skills/Handlers/Swordsman/Doppelsoeldner/DoublePayEarn.cs
+++ b/src/ZoneServer/Skills/Handlers/Swordsman/Doppelsoeldner/DoublePayEarn.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Melia.Shared.L10N;
+using Melia.Shared.Game.Const;
+using Melia.Shared.World;
+using Melia.Zone.Network;
+using Melia.Zone.Skills.Handlers.Base;
+using Melia.Zone.World.Actors;
+using Melia.Zone.World.Actors.CombatEntities.Components;
+
+namespace Melia.Zone.Skills.Handlers.Swordsman.Doppelsoeldner
+{
+	/// <summary>
+	/// Handler for the Doppelsoeldner skill Deeds of Valor.
+	/// </summary>
+	[SkillHandler(SkillId.Doppelsoeldner_Double_pay_earn)]
+	public class DoublePayEarn : ISelfSkillHandler
+	{
+		public const float damageTakenMultiplier = 2f;  // take double damage
+
+		/// <summary>
+		/// Handles skill, applying the buff to the caster.
+		/// </summary>
+		/// <param name="skill"></param>
+		/// <param name="caster"></param>
+		/// <param name="originPos"></param>
+		/// <param name="dir"></param>
+		public void Handle(Skill skill, ICombatEntity caster, Position originPos, Direction dir)
+		{
+			if (!caster.TrySpendSp(skill))
+			{
+				caster.ServerMessage(Localization.Get("Not enough SP."));
+				return;
+			}
+
+			skill.IncreaseOverheat();
+			caster.SetAttackState(true);
+
+			var target = caster;
+
+			var duration = TimeSpan.FromSeconds(60);
+			target.StartBuff(BuffId.Double_pay_earn_Buff, skill.Level, damageTakenMultiplier, duration, caster);
+
+			Send.ZC_SKILL_MELEE_TARGET(caster, skill, target, null);
+		}
+	}
+}

--- a/src/ZoneServer/Skills/Handlers/Swordsman/Doppelsoeldner/Punish.cs
+++ b/src/ZoneServer/Skills/Handlers/Swordsman/Doppelsoeldner/Punish.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Melia.Shared.Data.Database;
+using Melia.Shared.L10N;
+using Melia.Shared.Game.Const;
+using Melia.Shared.World;
+using Melia.Zone.Network;
+using Melia.Zone.Skills.Combat;
+using Melia.Zone.Skills.Handlers.Base;
+using Melia.Zone.Skills.SplashAreas;
+using Melia.Zone.World.Actors;
+using Melia.Zone.World.Actors.CombatEntities.Components;
+using static Melia.Zone.Skills.SkillUseFunctions;
+using Melia.Zone.World.Actors.Characters;
+
+namespace Melia.Zone.Skills.Handlers.Swordsman.Doppelsoeldner
+{
+	/// <summary>
+	/// Handler for the Doppelsoeldner skill Punish.
+	/// </summary>
+	[SkillHandler(SkillId.Doppelsoeldner_Punish)]
+	public class Punish : IGroundSkillHandler
+	{
+		private const float MaxMoveDistance = 140f;  // Will attempt to move up to 140 units
+		private const float KnockdownMultiplier = 1.5f;  // 50% bonus damage against knocked down enemies
+
+		/// <summary>
+		/// Handles skill, damaging targets.
+		/// </summary>
+		/// <param name="skill"></param>
+		/// <param name="caster"></param>
+		/// <param name="originPos"></param>
+		/// <param name="farPos"></param>
+		public void Handle(Skill skill, ICombatEntity caster, Position originPos, Position farPos, ICombatEntity target)
+		{
+			if (!caster.TrySpendSp(skill))
+			{
+				caster.ServerMessage(Localization.Get("Not enough SP."));
+				return;
+			}
+
+			skill.IncreaseOverheat();
+			caster.TurnTowards(target.Position);
+			caster.SetAttackState(true);
+
+			// Punish will attempt to move you to towards the target before it activates.  We subtract 30 so the center of the circle hits the enemy
+			var distanceToTarget = caster.Position.Get2DDistance(target.Position) - 30d;
+
+			// If the distance to jump is < 0 (ie, the target is already within range), you don't move
+			if (distanceToTarget > 0)
+			{
+				var movementDistance = Math.Min(distanceToTarget, MaxMoveDistance);
+				caster.Position = caster.Position.GetRelative(caster.Direction, (float)movementDistance);
+				Send.ZC_SET_POS(caster);
+			}
+
+			var splashParam = skill.GetSplashParameters(caster, caster.Position, caster.Position, length: 30, width: 30, angle: 0);
+			var splashArea = skill.GetSplashArea(SplashType.Circle, splashParam);
+
+			Send.ZC_SKILL_READY(caster, skill, originPos, farPos);
+			Send.ZC_SKILL_MELEE_GROUND(caster, skill, farPos, null);
+
+			this.Attack(skill, caster, splashArea);
+		}
+
+		/// <summary>
+		/// Executes the actual attack after a delay.
+		/// </summary>
+		/// <param name="skill"></param>
+		/// <param name="caster"></param>
+		/// <param name="splashArea"></param>
+		private async void Attack(Skill skill, ICombatEntity caster, ISplashArea splashArea)
+		{
+			var hitDelay = TimeSpan.FromMilliseconds(400);
+			var damageDelay = TimeSpan.FromMilliseconds(100);
+			var skillHitDelay = TimeSpan.Zero;
+			var deedsOfValorBonus = 1.0f;
+
+			if (caster.IsBuffActive(BuffId.DeedsOfValor))
+			{
+				var buff = caster.Components.Get<BuffComponent>().Get(BuffId.DeedsOfValor);
+				deedsOfValorBonus = buff.NumArg2;
+			}
+
+			await Task.Delay(hitDelay);
+
+			await Task.Delay(hitDelay);
+
+			var targets = caster.Map.GetAttackableEntitiesIn(caster, splashArea);
+			var hits = new List<SkillHitInfo>();
+
+			foreach (var target in targets.LimitBySDR(caster, skill))
+			{
+				SkillModifier modifier = new SkillModifier();
+
+				// need to add bonus damage if target is in knockdown state
+
+				var skillHitResult = SCR_SkillHit(caster, target, skill, modifier);
+				skillHitResult.Damage *= deedsOfValorBonus;
+				target.TakeDamage(skillHitResult.Damage, caster);
+
+				var skillHit = new SkillHitInfo(caster, target, skill, skillHitResult, damageDelay, skillHitDelay);
+				skillHit.HitEffect = HitEffect.Impact;
+				hits.Add(skillHit);
+			}
+
+			Send.ZC_SKILL_HIT_INFO(caster, hits);
+		}
+	}
+}
+
+

--- a/src/ZoneServer/Skills/Handlers/Swordsman/Doppelsoeldner/Redel.cs
+++ b/src/ZoneServer/Skills/Handlers/Swordsman/Doppelsoeldner/Redel.cs
@@ -88,7 +88,11 @@ namespace Melia.Zone.Skills.Handlers.Swordsman.Doppelsoeldner
 
 			foreach (var target in targets.LimitBySDR(caster, skill))
 			{
-				var skillHitResult = SCR_SkillHit(caster, target, skill);
+				SkillModifier modifier = new SkillModifier();
+
+				modifier.HitCount = 2;
+
+				var skillHitResult = SCR_SkillHit(caster, target, skill, modifier);
 				skillHitResult.Damage *= deedsOfValorBonus;
 				target.TakeDamage(skillHitResult.Damage, caster);
 
@@ -104,7 +108,11 @@ namespace Melia.Zone.Skills.Handlers.Swordsman.Doppelsoeldner
 
 			foreach (var target in targets.LimitBySDR(caster, skill))
 			{
-				var skillHitResult2 = SCR_SkillHit(caster, target, skill);
+				SkillModifier modifier = new SkillModifier();
+
+				modifier.HitCount = 2;
+
+				var skillHitResult2 = SCR_SkillHit(caster, target, skill, modifier);
 				skillHitResult2.Damage *= deedsOfValorBonus;
 				target.TakeDamage(skillHitResult2.Damage, caster);
 
@@ -120,7 +128,11 @@ namespace Melia.Zone.Skills.Handlers.Swordsman.Doppelsoeldner
 
 			foreach (var target in targets.LimitBySDR(caster, skill))
 			{
-				var skillHitResult3 = SCR_SkillHit(caster, target, skill);
+				SkillModifier modifier = new SkillModifier();
+
+				modifier.HitCount = 2;
+
+				var skillHitResult3 = SCR_SkillHit(caster, target, skill, modifier);
 				skillHitResult3.Damage *= deedsOfValorBonus;
 				target.TakeDamage(skillHitResult3.Damage, caster);
 
@@ -136,7 +148,11 @@ namespace Melia.Zone.Skills.Handlers.Swordsman.Doppelsoeldner
 
 			foreach (var target in targets.LimitBySDR(caster, skill))
 			{
-				var skillHitResult4 = SCR_SkillHit(caster, target, skill);
+				SkillModifier modifier = new SkillModifier();
+
+				modifier.HitCount = 2;
+
+				var skillHitResult4 = SCR_SkillHit(caster, target, skill, modifier);
 				skillHitResult4.Damage *= deedsOfValorBonus;
 				target.TakeDamage(skillHitResult4.Damage, caster);
 
@@ -152,7 +168,11 @@ namespace Melia.Zone.Skills.Handlers.Swordsman.Doppelsoeldner
 
 			foreach (var target in targets.LimitBySDR(caster, skill))
 			{
-				var skillHitResult5 = SCR_SkillHit(caster, target, skill);
+				SkillModifier modifier = new SkillModifier();
+
+				modifier.HitCount = 2;
+
+				var skillHitResult5 = SCR_SkillHit(caster, target, skill, modifier);
 				skillHitResult5.Damage *= deedsOfValorBonus;
 				target.TakeDamage(skillHitResult5.Damage, caster);
 

--- a/src/ZoneServer/Skills/Handlers/Swordsman/Doppelsoeldner/Redel.cs
+++ b/src/ZoneServer/Skills/Handlers/Swordsman/Doppelsoeldner/Redel.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Melia.Shared.Data.Database;
+using Melia.Shared.L10N;
+using Melia.Shared.Game.Const;
+using Melia.Shared.World;
+using Melia.Zone.Network;
+using Melia.Zone.Skills.Combat;
+using Melia.Zone.Skills.Handlers.Base;
+using Melia.Zone.Skills.SplashAreas;
+using Melia.Zone.World.Actors;
+using Melia.Zone.World.Actors.Characters.Components;
+using Melia.Zone.World.Actors.CombatEntities.Components;
+using static Melia.Zone.Skills.SkillUseFunctions;
+
+namespace Melia.Zone.Skills.Handlers.Swordsman.Doppelsoeldner
+{
+	/// <summary>
+	/// Handler for the Doppelsoeldner skill Redel.
+	/// </summary>
+	[SkillHandler(SkillId.Doppelsoeldner_Redel)]
+	public class Redel : IGroundSkillHandler
+	{
+		/// <summary>
+		/// Handles skill, damaging targets.
+		/// </summary>
+		/// <param name="skill"></param>
+		/// <param name="caster"></param>
+		/// <param name="originPos"></param>
+		/// <param name="farPos"></param>
+		public void Handle(Skill skill, ICombatEntity caster, Position originPos, Position farPos, ICombatEntity target)
+		{
+			if (!caster.TrySpendSp(skill))
+			{
+				caster.ServerMessage(Localization.Get("Not enough SP."));
+				return;
+			}
+
+			// This is a combo skill, can only be cast when the previous skills adds this buff
+			if (!caster.IsBuffActive(BuffId.Redel_Buff))
+			{
+				caster.ServerMessage(Localization.Get("Can't use this skill."));
+				return;
+			}
+			var buffComponent = caster.Components.Get<BuffComponent>();
+			if (buffComponent.Has(BuffId.Redel_Buff))
+				buffComponent.Remove(BuffId.Redel_Buff);
+
+			skill.IncreaseOverheat();
+			caster.TurnTowards(farPos);
+			caster.SetAttackState(true);
+
+			var splashParam = skill.GetSplashParameters(caster, originPos, farPos, length: 70, width: 30, angle: 0);
+			var splashArea = skill.GetSplashArea(SplashType.Square, splashParam);
+
+			Send.ZC_SKILL_READY(caster, skill, originPos, farPos);
+			Send.ZC_SKILL_MELEE_GROUND(caster, skill, farPos, null);
+
+			this.Attack(skill, caster, splashArea);
+		}
+
+		/// <summary>
+		/// Executes the actual attack after a delay.
+		/// </summary>
+		/// <param name="skill"></param>
+		/// <param name="caster"></param>
+		/// <param name="splashArea"></param>
+		private async void Attack(Skill skill, ICombatEntity caster, ISplashArea splashArea)
+		{
+			var hitDelay = TimeSpan.FromMilliseconds(600);
+			var damageDelay1 = TimeSpan.FromMilliseconds(50);
+			var damageDelay2 = TimeSpan.FromMilliseconds(50);
+			var delayBetweenHits = TimeSpan.FromMilliseconds(200);
+			var skillHitDelay = TimeSpan.Zero;
+			var deedsOfValorBonus = 1.0f;
+
+			if (caster.IsBuffActive(BuffId.DeedsOfValor))
+			{
+				var buff = caster.Components.Get<BuffComponent>().Get(BuffId.DeedsOfValor);
+				deedsOfValorBonus = buff.NumArg2;
+			}
+
+			await Task.Delay(hitDelay);
+
+			var targets = caster.Map.GetAttackableEntitiesIn(caster, splashArea);
+			var hits = new List<SkillHitInfo>();
+
+			foreach (var target in targets.LimitBySDR(caster, skill))
+			{
+				var skillHitResult = SCR_SkillHit(caster, target, skill);
+				skillHitResult.Damage *= deedsOfValorBonus;
+				target.TakeDamage(skillHitResult.Damage, caster);
+
+				var skillHit = new SkillHitInfo(caster, target, skill, skillHitResult, damageDelay1, skillHitDelay);
+				skillHit.HitEffect = HitEffect.Impact;
+				hits.Add(skillHit);
+				Send.ZC_SKILL_HIT_INFO(caster, hits);
+			}
+
+			await Task.Delay(delayBetweenHits);
+			hits.Clear();
+			targets = caster.Map.GetAttackableEntitiesIn(caster, splashArea);
+
+			foreach (var target in targets.LimitBySDR(caster, skill))
+			{
+				var skillHitResult2 = SCR_SkillHit(caster, target, skill);
+				skillHitResult2.Damage *= deedsOfValorBonus;
+				target.TakeDamage(skillHitResult2.Damage, caster);
+
+				var skillHit2 = new SkillHitInfo(caster, target, skill, skillHitResult2, damageDelay2, skillHitDelay);
+				skillHit2.HitEffect = HitEffect.Impact;
+				hits.Add(skillHit2);
+				Send.ZC_SKILL_HIT_INFO(caster, hits);
+			}
+
+			await Task.Delay(delayBetweenHits);
+			hits.Clear();
+			targets = caster.Map.GetAttackableEntitiesIn(caster, splashArea);
+
+			foreach (var target in targets.LimitBySDR(caster, skill))
+			{
+				var skillHitResult3 = SCR_SkillHit(caster, target, skill);
+				skillHitResult3.Damage *= deedsOfValorBonus;
+				target.TakeDamage(skillHitResult3.Damage, caster);
+
+				var skillHit3 = new SkillHitInfo(caster, target, skill, skillHitResult3, damageDelay2, skillHitDelay);
+				skillHit3.HitEffect = HitEffect.Impact;
+				hits.Add(skillHit3);
+				Send.ZC_SKILL_HIT_INFO(caster, hits);
+			}
+
+			await Task.Delay(delayBetweenHits);
+			hits.Clear();
+			targets = caster.Map.GetAttackableEntitiesIn(caster, splashArea);
+
+			foreach (var target in targets.LimitBySDR(caster, skill))
+			{
+				var skillHitResult4 = SCR_SkillHit(caster, target, skill);
+				skillHitResult4.Damage *= deedsOfValorBonus;
+				target.TakeDamage(skillHitResult4.Damage, caster);
+
+				var skillHit4 = new SkillHitInfo(caster, target, skill, skillHitResult4, damageDelay2, skillHitDelay);
+				skillHit4.HitEffect = HitEffect.Impact;
+				hits.Add(skillHit4);
+				Send.ZC_SKILL_HIT_INFO(caster, hits);
+			}
+
+			await Task.Delay(delayBetweenHits);
+			hits.Clear();
+			targets = caster.Map.GetAttackableEntitiesIn(caster, splashArea);
+
+			foreach (var target in targets.LimitBySDR(caster, skill))
+			{
+				var skillHitResult5 = SCR_SkillHit(caster, target, skill);
+				skillHitResult5.Damage *= deedsOfValorBonus;
+				target.TakeDamage(skillHitResult5.Damage, caster);
+
+				var skillHit5 = new SkillHitInfo(caster, target, skill, skillHitResult5, damageDelay2, skillHitDelay);
+				skillHit5.HitEffect = HitEffect.Impact;
+				hits.Add(skillHit5);
+				Send.ZC_SKILL_HIT_INFO(caster, hits);
+			}
+		}
+	}
+}

--- a/src/ZoneServer/Skills/Handlers/Swordsman/Doppelsoeldner/Zornhau.cs
+++ b/src/ZoneServer/Skills/Handlers/Swordsman/Doppelsoeldner/Zornhau.cs
@@ -13,6 +13,7 @@ using Melia.Zone.World.Actors;
 using Melia.Zone.World.Actors.CombatEntities.Components;
 using static Melia.Zone.Skills.SkillUseFunctions;
 using Yggdrasil.Logging;
+using Yggdrasil.Util;
 
 namespace Melia.Zone.Skills.Handlers.Swordsman.Doppelsoeldner
 {
@@ -22,6 +23,7 @@ namespace Melia.Zone.Skills.Handlers.Swordsman.Doppelsoeldner
 	[SkillHandler(SkillId.Doppelsoeldner_Zornhau)]
 	public class Zornhau : IGroundSkillHandler
 	{
+		private const int BuffRemoveChancePerLevel = 5;
 		private const int ShockDuration = 5;
 
 		/// <summary>
@@ -85,7 +87,7 @@ namespace Melia.Zone.Skills.Handlers.Swordsman.Doppelsoeldner
 
 				// Deeds of Valor specifically influences final damage so we just multiply the damage after calculation
 
-				var skillHitResult = SCR_SkillHit(caster, target, skill, modifier);		
+				var skillHitResult = SCR_SkillHit(caster, target, skill, modifier);
 				skillHitResult.Damage *= deedsOfValorBonus;
 				target.TakeDamage(skillHitResult.Damage, caster);
 
@@ -93,9 +95,16 @@ namespace Melia.Zone.Skills.Handlers.Swordsman.Doppelsoeldner
 				skillHit.HitEffect = HitEffect.Impact;
 				hits.Add(skillHit);
 
+				// This debuff is seemingly not applied on official, even though the description mentions it
 				target.StartBuff(BuffId.Common_Shock, skill.Level, 0, TimeSpan.FromSeconds(ShockDuration), caster);
 
 				// Also need to remove a buff from the target
+				var buffRemoveChance = BuffRemoveChancePerLevel * skill.Level;
+				var rnd = RandomProvider.Get();
+				if (rnd.Next(100) < buffRemoveChance)
+				{
+					// TODO: Need to remove a buff here, this probably needs to be a function as many skills can do this
+				}
 			}
 
 			// Must hit at least 1 enemy to continue combo?

--- a/src/ZoneServer/Skills/Handlers/Swordsman/Doppelsoeldner/Zornhau.cs
+++ b/src/ZoneServer/Skills/Handlers/Swordsman/Doppelsoeldner/Zornhau.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Melia.Shared.Data.Database;
+using Melia.Shared.L10N;
+using Melia.Shared.Game.Const;
+using Melia.Shared.World;
+using Melia.Zone.Network;
+using Melia.Zone.Skills.Combat;
+using Melia.Zone.Skills.Handlers.Base;
+using Melia.Zone.Skills.SplashAreas;
+using Melia.Zone.World.Actors;
+using Melia.Zone.World.Actors.CombatEntities.Components;
+using static Melia.Zone.Skills.SkillUseFunctions;
+using Yggdrasil.Logging;
+
+namespace Melia.Zone.Skills.Handlers.Swordsman.Doppelsoeldner
+{
+	/// <summary>
+	/// Handler for the Doppelsoeldner skill Zornhau.
+	/// </summary>
+	[SkillHandler(SkillId.Doppelsoeldner_Zornhau)]
+	public class Zornhau : IGroundSkillHandler
+	{
+		private const int ShockDuration = 5;
+
+		/// <summary>
+		/// Handles skill, damaging targets.
+		/// </summary>
+		/// <param name="skill"></param>
+		/// <param name="caster"></param>
+		/// <param name="originPos"></param>
+		/// <param name="farPos"></param>
+		public void Handle(Skill skill, ICombatEntity caster, Position originPos, Position farPos, ICombatEntity target)
+		{
+			if (!caster.TrySpendSp(skill))
+			{
+				caster.ServerMessage(Localization.Get("Not enough SP."));
+				return;
+			}
+
+			skill.IncreaseOverheat();
+			caster.TurnTowards(farPos);
+			caster.SetAttackState(true);
+
+			var splashParam = skill.GetSplashParameters(caster, originPos, farPos, length: 70, width: 30, angle: 0);
+			var splashArea = skill.GetSplashArea(SplashType.Square, splashParam);
+
+			Send.ZC_SKILL_READY(caster, skill, originPos, farPos);
+			Send.ZC_SKILL_MELEE_GROUND(caster, skill, farPos, null);
+
+			this.Attack(skill, caster, splashArea);
+		}
+
+		/// <summary>
+		/// Executes the actual attack after a delay.
+		/// </summary>
+		/// <param name="skill"></param>
+		/// <param name="caster"></param>
+		/// <param name="splashArea"></param>
+		private async void Attack(Skill skill, ICombatEntity caster, ISplashArea splashArea)
+		{
+			var hitDelay = TimeSpan.FromMilliseconds(400);
+			var damageDelay = TimeSpan.FromMilliseconds(150);
+			var skillHitDelay = TimeSpan.Zero;
+			var deedsOfValorBonus = 1.0f;
+			
+			if (caster.IsBuffActive(BuffId.DeedsOfValor))
+			{
+				var buff = caster.Components.Get<BuffComponent>().Get(BuffId.DeedsOfValor);
+				deedsOfValorBonus = buff.NumArg2;
+			}
+
+			await Task.Delay(hitDelay);
+
+			var targets = caster.Map.GetAttackableEntitiesIn(caster, splashArea);
+			var hits = new List<SkillHitInfo>();
+
+			foreach (var target in targets.LimitBySDR(caster, skill))
+			{
+				SkillModifier modifier = new SkillModifier();
+
+				// This skill always hits twice
+				modifier.HitCount = 2;
+
+				// Deeds of Valor specifically influences final damage so we just multiply the damage after calculation
+
+				var skillHitResult = SCR_SkillHit(caster, target, skill, modifier);		
+				skillHitResult.Damage *= deedsOfValorBonus;
+				target.TakeDamage(skillHitResult.Damage, caster);
+
+				var skillHit = new SkillHitInfo(caster, target, skill, skillHitResult, damageDelay, skillHitDelay);
+				skillHit.HitEffect = HitEffect.Impact;
+				hits.Add(skillHit);
+
+				target.StartBuff(BuffId.Common_Shock, skill.Level, 0, TimeSpan.FromSeconds(ShockDuration), caster);
+
+				// Also need to remove a buff from the target
+			}
+
+			// Must hit at least 1 enemy to continue combo?
+			if (targets.Count > 0)
+			{
+				var duration = TimeSpan.FromSeconds(3);
+				caster.StartBuff(BuffId.Zucken_Buff, skill.Level, 0, duration, caster);
+			}
+
+			Send.ZC_SKILL_HIT_INFO(caster, hits);
+		}
+	}
+}
+

--- a/src/ZoneServer/Skills/Handlers/Swordsman/Doppelsoeldner/Zucken.cs
+++ b/src/ZoneServer/Skills/Handlers/Swordsman/Doppelsoeldner/Zucken.cs
@@ -91,7 +91,11 @@ namespace Melia.Zone.Skills.Handlers.Swordsman.Doppelsoeldner
 
 			foreach (var target in targets.LimitBySDR(caster, skill))
 			{
-				var skillHitResult = SCR_SkillHit(caster, target, skill);
+				SkillModifier modifier = new SkillModifier();
+
+				modifier.HitCount = 2;
+
+				var skillHitResult = SCR_SkillHit(caster, target, skill, modifier);
 				skillHitResult.Damage *= deedsOfValorBonus;
 				target.TakeDamage(skillHitResult.Damage, caster);
 
@@ -108,7 +112,11 @@ namespace Melia.Zone.Skills.Handlers.Swordsman.Doppelsoeldner
 
 			foreach (var target in targets.LimitBySDR(caster, skill))
 			{
-				var skillHitResult2 = SCR_SkillHit(caster, target, skill);
+				SkillModifier modifier = new SkillModifier();
+
+				modifier.HitCount = 2;
+
+				var skillHitResult2 = SCR_SkillHit(caster, target, skill, modifier);
 				skillHitResult2.Damage *= deedsOfValorBonus;
 				target.TakeDamage(skillHitResult2.Damage, caster);
 
@@ -125,7 +133,11 @@ namespace Melia.Zone.Skills.Handlers.Swordsman.Doppelsoeldner
 
 			foreach (var target in targets.LimitBySDR(caster, skill))
 			{
-				var skillHitResult3 = SCR_SkillHit(caster, target, skill);
+				SkillModifier modifier = new SkillModifier();
+
+				modifier.HitCount = 2;
+
+				var skillHitResult3 = SCR_SkillHit(caster, target, skill, modifier);
 				skillHitResult3.Damage *= deedsOfValorBonus;
 				target.TakeDamage(skillHitResult3.Damage, caster);
 
@@ -142,7 +154,11 @@ namespace Melia.Zone.Skills.Handlers.Swordsman.Doppelsoeldner
 
 			foreach (var target in targets.LimitBySDR(caster, skill))
 			{
-				var skillHitResult4 = SCR_SkillHit(caster, target, skill);
+				SkillModifier modifier = new SkillModifier();
+
+				modifier.HitCount = 2;
+
+				var skillHitResult4 = SCR_SkillHit(caster, target, skill, modifier);
 				skillHitResult4.Damage *= deedsOfValorBonus;
 				target.TakeDamage(skillHitResult4.Damage, caster);
 

--- a/src/ZoneServer/Skills/Handlers/Swordsman/Doppelsoeldner/Zucken.cs
+++ b/src/ZoneServer/Skills/Handlers/Swordsman/Doppelsoeldner/Zucken.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Melia.Shared.Data.Database;
+using Melia.Shared.L10N;
+using Melia.Shared.Game.Const;
+using Melia.Shared.World;
+using Melia.Zone.Network;
+using Melia.Zone.Skills.Combat;
+using Melia.Zone.Skills.Handlers.Base;
+using Melia.Zone.Skills.SplashAreas;
+using Melia.Zone.World.Actors;
+using Melia.Zone.World.Actors.Characters.Components;
+using Melia.Zone.World.Actors.CombatEntities.Components;
+using static Melia.Zone.Skills.SkillUseFunctions;
+
+namespace Melia.Zone.Skills.Handlers.Swordsman.Doppelsoeldner
+{
+	/// <summary>
+	/// Handler for the Doppelsoeldner skill Zucken.
+	/// </summary>
+	[SkillHandler(SkillId.Doppelsoeldner_Zucken)]
+	public class Zucken : IGroundSkillHandler
+	{
+		/// <summary>
+		/// Handles skill, damaging targets.
+		/// </summary>
+		/// <param name="skill"></param>
+		/// <param name="caster"></param>
+		/// <param name="originPos"></param>
+		/// <param name="farPos"></param>
+		public void Handle(Skill skill, ICombatEntity caster, Position originPos, Position farPos, ICombatEntity target)
+		{
+			if (!caster.TrySpendSp(skill))
+			{
+				caster.ServerMessage(Localization.Get("Not enough SP."));
+				return;
+			}
+
+			// This is a combo skill, can only be cast when the previous skills adds this buff
+			if (!caster.IsBuffActive(BuffId.Zucken_Buff))
+			{
+				caster.ServerMessage(Localization.Get("Can't use this skill."));
+				return;
+			}
+			var buffComponent = caster.Components.Get<BuffComponent>();
+			if (buffComponent.Has(BuffId.Zucken_Buff))
+				buffComponent.Remove(BuffId.Zucken_Buff);
+
+
+			skill.IncreaseOverheat();
+			caster.TurnTowards(farPos);
+			caster.SetAttackState(true);
+
+			var splashParam = skill.GetSplashParameters(caster, originPos, farPos, length: 70, width: 30, angle: 0);
+			var splashArea = skill.GetSplashArea(SplashType.Square, splashParam);
+
+			Send.ZC_SKILL_READY(caster, skill, originPos, farPos);
+			Send.ZC_SKILL_MELEE_GROUND(caster, skill, farPos, null);
+
+			this.Attack(skill, caster, splashArea);
+		}
+
+		/// <summary>
+		/// Executes the actual attack after a delay.
+		/// </summary>
+		/// <param name="skill"></param>
+		/// <param name="caster"></param>
+		/// <param name="splashArea"></param>
+		private async void Attack(Skill skill, ICombatEntity caster, ISplashArea splashArea)
+		{
+			var hitDelay = TimeSpan.FromMilliseconds(400);
+			var damageDelay1 = TimeSpan.FromMilliseconds(60);
+			var damageDelay2 = TimeSpan.FromMilliseconds(60);
+			var delayBetweenHits = TimeSpan.FromMilliseconds(150);
+			var skillHitDelay = TimeSpan.Zero;
+			var deedsOfValorBonus = 1.0f;
+
+			if (caster.IsBuffActive(BuffId.DeedsOfValor))
+			{
+				var buff = caster.Components.Get<BuffComponent>().Get(BuffId.DeedsOfValor);
+				deedsOfValorBonus = buff.NumArg2;
+			}
+
+			await Task.Delay(hitDelay);
+
+			var targets = caster.Map.GetAttackableEntitiesIn(caster, splashArea);
+			var hits = new List<SkillHitInfo>();
+
+			var hitSomething = false;
+
+			foreach (var target in targets.LimitBySDR(caster, skill))
+			{
+				var skillHitResult = SCR_SkillHit(caster, target, skill);
+				skillHitResult.Damage *= deedsOfValorBonus;
+				target.TakeDamage(skillHitResult.Damage, caster);
+
+				var skillHit = new SkillHitInfo(caster, target, skill, skillHitResult, damageDelay1, skillHitDelay);
+				skillHit.HitEffect = HitEffect.Impact;
+				hits.Add(skillHit);
+				Send.ZC_SKILL_HIT_INFO(caster, hits);
+				hitSomething = true;
+			}
+
+			await Task.Delay(delayBetweenHits);
+			hits.Clear();
+			targets = caster.Map.GetAttackableEntitiesIn(caster, splashArea);
+
+			foreach (var target in targets.LimitBySDR(caster, skill))
+			{
+				var skillHitResult2 = SCR_SkillHit(caster, target, skill);
+				skillHitResult2.Damage *= deedsOfValorBonus;
+				target.TakeDamage(skillHitResult2.Damage, caster);
+
+				var skillHit2 = new SkillHitInfo(caster, target, skill, skillHitResult2, damageDelay2, skillHitDelay);
+				skillHit2.HitEffect = HitEffect.Impact;
+				hits.Add(skillHit2);
+				Send.ZC_SKILL_HIT_INFO(caster, hits);
+				hitSomething = true;
+			}
+
+			await Task.Delay(delayBetweenHits);
+			hits.Clear();
+			targets = caster.Map.GetAttackableEntitiesIn(caster, splashArea);
+
+			foreach (var target in targets.LimitBySDR(caster, skill))
+			{
+				var skillHitResult3 = SCR_SkillHit(caster, target, skill);
+				skillHitResult3.Damage *= deedsOfValorBonus;
+				target.TakeDamage(skillHitResult3.Damage, caster);
+
+				var skillHit3 = new SkillHitInfo(caster, target, skill, skillHitResult3, damageDelay2, skillHitDelay);
+				skillHit3.HitEffect = HitEffect.Impact;
+				hits.Add(skillHit3);
+				Send.ZC_SKILL_HIT_INFO(caster, hits);
+				hitSomething = true;
+			}
+
+			await Task.Delay(delayBetweenHits);
+			hits.Clear();
+			targets = caster.Map.GetAttackableEntitiesIn(caster, splashArea);
+
+			foreach (var target in targets.LimitBySDR(caster, skill))
+			{
+				var skillHitResult4 = SCR_SkillHit(caster, target, skill);
+				skillHitResult4.Damage *= deedsOfValorBonus;
+				target.TakeDamage(skillHitResult4.Damage, caster);
+
+				var skillHit4 = new SkillHitInfo(caster, target, skill, skillHitResult4, damageDelay2, skillHitDelay);
+				skillHit4.HitEffect = HitEffect.Impact;
+				hits.Add(skillHit4);
+				Send.ZC_SKILL_HIT_INFO(caster, hits);
+				hitSomething = true;
+			}
+
+
+			if (hitSomething)
+			{
+				var duration = TimeSpan.FromSeconds(3);
+				caster.StartBuff(BuffId.Redel_Buff, skill.Level, 0, duration, caster);
+			}
+		}
+	}
+}

--- a/src/ZoneServer/Skills/SkillUseFunctions.cs
+++ b/src/ZoneServer/Skills/SkillUseFunctions.cs
@@ -22,12 +22,12 @@ namespace Melia.Zone.Skills
 		/// Thrown if the skill use function with the given name was not
 		/// defined.
 		/// </exception>
-		public static SkillHitResult Call(string name, ICombatEntity caster, ICombatEntity target, Skill skill)
+		public static SkillHitResult Call(string name, ICombatEntity caster, ICombatEntity target, Skill skill, SkillModifier modifier)
 		{
 			if (!ScriptableFunctions.SkillHit.TryGet(name, out var func))
 				throw new ArgumentException($"Scriptable function '{name}' was not defined.");
 
-			return func(caster, target, skill);
+			return func(caster, target, skill, modifier);
 		}
 
 		/// <summary>
@@ -43,12 +43,12 @@ namespace Melia.Zone.Skills
 		/// Thrown if the skill use function with the given name was not
 		/// defined.
 		/// </exception>
-		public static float Call(string name, ICombatEntity caster, ICombatEntity target, Skill skill, SkillHitResult skillHitResult)
+		public static float Call(string name, ICombatEntity caster, ICombatEntity target, Skill skill, SkillModifier modifier, SkillHitResult skillHitResult)
 		{
 			if (!ScriptableFunctions.Combat.TryGet(name, out var func))
 				throw new ArgumentException($"Scriptable function '{name}' was not defined.");
 
-			return func(caster, target, skill, skillHitResult);
+			return func(caster, target, skill, modifier, skillHitResult);
 		}
 
 		/// <summary>
@@ -60,8 +60,8 @@ namespace Melia.Zone.Skills
 		/// <param name="skill"></param>
 		/// <param name="skillHitInfo"></param>
 		/// <returns></returns>
-		public static float SCR_GetRandomAtk(ICombatEntity caster, ICombatEntity target, Skill skill, SkillHitResult skillHitResult)
-			=> Call("SCR_GetRandomAtk", caster, target, skill, skillHitResult);
+		public static float SCR_GetRandomAtk(ICombatEntity caster, ICombatEntity target, Skill skill, SkillModifier modifier, SkillHitResult skillHitResult)
+			=> Call("SCR_GetRandomAtk", caster, target, skill, modifier, skillHitResult);
 
 		/// <summary>
 		/// Calculates the damage for the given skill if used by the attacker
@@ -72,8 +72,8 @@ namespace Melia.Zone.Skills
 		/// <param name="skill"></param>
 		/// <param name="skillHitInfo"></param>
 		/// <returns></returns>
-		public static float SCR_CalculateDamage(ICombatEntity caster, ICombatEntity target, Skill skill, SkillHitResult skillHitResult)
-			=> Call("SCR_CalculateDamage", caster, target, skill, skillHitResult);
+		public static float SCR_CalculateDamage(ICombatEntity caster, ICombatEntity target, Skill skill, SkillModifier modifier, SkillHitResult skillHitResult)
+			=> Call("SCR_CalculateDamage", caster, target, skill, modifier, skillHitResult);
 
 		/// <summary>
 		/// Determines the result of skill hitting the target.
@@ -83,6 +83,16 @@ namespace Melia.Zone.Skills
 		/// <param name="skill"></param>
 		/// <returns></returns>
 		public static SkillHitResult SCR_SkillHit(ICombatEntity caster, ICombatEntity target, Skill skill)
-			=> Call("SCR_SkillHit", caster, target, skill);
+			=> Call("SCR_SkillHit", caster, target, skill, new SkillModifier());
+
+		/// <summary>
+		/// Determines the result of skill hitting the target with the indicated skill modifiers
+		/// </summary>
+		/// <param name="caster"></param>
+		/// <param name="target"></param>
+		/// <param name="skill"></param>
+		/// <returns></returns>
+		public static SkillHitResult SCR_SkillHit(ICombatEntity caster, ICombatEntity target, Skill skill, SkillModifier modifier)
+			=> Call("SCR_SkillHit", caster, target, skill, modifier);
 	}
 }

--- a/src/ZoneServer/World/Actors/Monsters/Mob.cs
+++ b/src/ZoneServer/World/Actors/Monsters/Mob.cs
@@ -455,9 +455,9 @@ namespace Melia.Zone.World.Actors.Monsters
 
 				var originalDropChance = dropItemData.DropChance;
 				var adjustedDropChance = GetAdjustedDropRate(dropItemData);
-				// Each point of looting rate increases drops by 0.1%, so 500 looting rate = 50% drop bonus
-				var lootingRateBonus = 1f + (killer.Properties.GetFloat(PropertyName.LootingChance) + killer.Properties.GetFloat(PropertyName.LootingChance_BM)) * 0.01f;
-				adjustedDropChance *= lootingRateBonus;
+				// Each point of looting chance increases drops by 0.1%, so 500 looting chance = 1.5x drop rate
+				var lootingRate = 1f + (killer.Properties.GetFloat(PropertyName.LootingChance) + killer.Properties.GetFloat(PropertyName.LootingChance_BM)) * 0.001f;
+				adjustedDropChance *= lootingRate;
 
 				// Items with a chance of >0.5% always drop on super drop.
 				// We'll use the original drop chance for this check to

--- a/src/ZoneServer/World/Actors/Monsters/Mob.cs
+++ b/src/ZoneServer/World/Actors/Monsters/Mob.cs
@@ -455,6 +455,9 @@ namespace Melia.Zone.World.Actors.Monsters
 
 				var originalDropChance = dropItemData.DropChance;
 				var adjustedDropChance = GetAdjustedDropRate(dropItemData);
+				// Each point of looting rate increases drops by 0.1%, so 500 looting rate = 50% drop bonus
+				var lootingRateBonus = 1f + (killer.Properties.GetFloat(PropertyName.LootingChance) + killer.Properties.GetFloat(PropertyName.LootingChance_BM)) * 0.01f;
+				adjustedDropChance *= lootingRateBonus;
 
 				// Items with a chance of >0.5% always drop on super drop.
 				// We'll use the original drop chance for this check to


### PR DESCRIPTION
Adds Doppel's 5 tier 1 abilities and Double Pay Earn (which was removed).  Also includes the basic attack for 2 handed swords and Shock, one of the common status ailments.  Punish does not yet deal increased damage to targets that are knocked down, as Knockdown is not implemented yet.