### PR TITLE
Update to templates based on Map Changes

### DIFF
--- a/doc/bt/ZC_MAP_REVEAL_LIST.bt
+++ b/doc/bt/ZC_MAP_REVEAL_LIST.bt
@@ -20,4 +20,5 @@ int count;
 if (!checkCompression())
 {
     mapRevealData dataSets[count];
+    float spacer;
 }

--- a/doc/bt/inc/MapRevealData.bt
+++ b/doc/bt/inc/MapRevealData.bt
@@ -15,8 +15,7 @@ typedef struct
 {
     int mapId;
     ubyte data[128];
-    float mapExplored1;
-    float mapExplored2;
+    float percentageExplored;
 }
 mapRevealData <read=mapRevealDataRead>;
 

--- a/src/ZoneServer/Network/PacketHandler.cs
+++ b/src/ZoneServer/Network/PacketHandler.cs
@@ -1636,7 +1636,7 @@ namespace Melia.Zone.Network
 			// Check the percentage for validity
 			if (percentage < 0 || percentage > 100)
 			{
-				Log.Warning("CZ_MAP_SEARCH_INFO: User '{0}' tried to update the visibility for map '{1}' beyond an acceptable percentage.", conn.Account.Name, mapId);
+				Log.Warning("CZ_MAP_REVEAL_INFO: User '{0}' tried to update the visibility for map '{1}' beyond an acceptable percentage.", conn.Account.Name, mapId);
 				return;
 			}
 
@@ -1646,8 +1646,10 @@ namespace Melia.Zone.Network
 
 		/// <summary>
 		/// Reports to the server a percentage of the map that has been explored.
-		/// This packet is seemingly no longer used, it's been combined with the above
 		/// </summary>
+		/// <remarks>
+		/// Doesn't seem to be used anymore, map percentage is sent in CZ_MAP_REVEAL_INFO
+		/// </remarks>
 		/// <param name="conn"></param>
 		/// <param name="packet"></param>
 		[PacketHandler(Op.CZ_MAP_SEARCH_INFO)]


### PR DESCRIPTION
As mentioned in the previous PR for this feature, there were some documentation changes requested. Note that MapRevealData does not include a second float, attempting to get another float gives the end of buffer error.  It seems the extra float sent while sending the data to the client is just a spacer.