### PR TITLE
Adding Red Orb Pets

### DIFF
--- a/src/Shared/Configuration/Files/World.cs
+++ b/src/Shared/Configuration/Files/World.cs
@@ -47,7 +47,10 @@ namespace Melia.Shared.Configuration.Files
 
 		// summons.conf
 		public bool BlueOrbFollowWarp { get; protected set; }
+		public bool BlueOrbUnlimitedDuration { get; protected set; }
+		public bool BlueOrbScaleToLevel { get; protected set; }
 		public bool BlueOrbPetSystem { get; protected set; }
+		public bool RedOrbPetSystem { get; protected set; }
 
 		// rare_monsters.conf
 		public float BlueJackpotSpawnChance { get; protected set; }
@@ -110,7 +113,10 @@ namespace Melia.Shared.Configuration.Files
 			this.AbilityPointCost = this.GetInt("ability_point_cost", 1000);
 
 			this.BlueOrbFollowWarp = this.GetBool("blue_orb_follow_warp", false);
+			this.BlueOrbUnlimitedDuration = this.GetBool("blue_orb_unlimited_duration", false);
+			this.BlueOrbScaleToLevel = this.GetBool("blue_orb_unlimited_duration", false);
 			this.BlueOrbPetSystem = this.GetBool("blue_orb_pet_system", false);
+			this.RedOrbPetSystem = this.GetBool("red_orb_pet_system", false);
 
 			this.BlueJackpotSpawnChance = this.GetFloat("blue_jackpot_spawn_chance", 0.05f);
 			this.BlueJackpotExpRate = this.GetFloat("blue_jackpot_exp_rate", 10000);

--- a/src/ZoneServer/Network/Send.cs
+++ b/src/ZoneServer/Network/Send.cs
@@ -465,13 +465,6 @@ namespace Melia.Zone.Network
 
 			var skillId = skill.Id;
 
-			// This is a silly workaround for monsters using player skills
-			// that allows them to use their standard attack animation
-			if (entity is Mob mob && !skill.IsMonsterSkill)
-			{
-				skillId = mob.Data.Skills.First().SkillId;
-			}
-
 			var packet = new Packet(Op.ZC_SKILL_MELEE_GROUND);
 			packet.PutInt((int)skillId);
 			packet.PutInt(entity.Handle);

--- a/src/ZoneServer/Network/Send.cs
+++ b/src/ZoneServer/Network/Send.cs
@@ -465,7 +465,16 @@ namespace Melia.Zone.Network
 
 			var packet = new Packet(Op.ZC_SKILL_MELEE_GROUND);
 
-			packet.PutInt((int)skill.Id);
+			var skillId = skill.Id;
+
+			// This is a silly workaround for monsters using player skills
+			// that allows them to use their standard attack animation
+			if (entity is Mob mob && !skill.IsMonsterSkill)
+			{
+				skillId = mob.Data.Skills.First().SkillId;
+			}
+
+			packet.PutInt((int)skillId);
 			packet.PutInt(entity.Handle);
 			packet.PutFloat(entity.Direction.Cos);
 			packet.PutFloat(entity.Direction.Sin);

--- a/src/ZoneServer/Network/Send.cs
+++ b/src/ZoneServer/Network/Send.cs
@@ -463,8 +463,6 @@ namespace Melia.Zone.Network
 			var shootTime = skill.Properties.GetFloat(PropertyName.ShootTime);
 			var sklSpdRate = skill.Properties.GetFloat(PropertyName.SklSpdRate);
 
-			var packet = new Packet(Op.ZC_SKILL_MELEE_GROUND);
-
 			var skillId = skill.Id;
 
 			// This is a silly workaround for monsters using player skills
@@ -474,6 +472,7 @@ namespace Melia.Zone.Network
 				skillId = mob.Data.Skills.First().SkillId;
 			}
 
+			var packet = new Packet(Op.ZC_SKILL_MELEE_GROUND);
 			packet.PutInt((int)skillId);
 			packet.PutInt(entity.Handle);
 			packet.PutFloat(entity.Direction.Cos);

--- a/src/ZoneServer/Scripting/AI/AiScript.Routines.cs
+++ b/src/ZoneServer/Scripting/AI/AiScript.Routines.cs
@@ -152,7 +152,9 @@ namespace Melia.Zone.Scripting.AI
 			//var rndSkillId = mob.Data.Skills.Random().SkillId;
 
 			if (mob.ExtraSkill != null && RandomProvider.Get().Next(100) <= mob.ExtraSkillUseRate)
+			{
 				skill = mob.ExtraSkill;
+			}
 			else
 			{
 				var rndSkillId = mob.Data.Skills.First().SkillId;

--- a/src/ZoneServer/Scripting/AI/AiScript.Routines.cs
+++ b/src/ZoneServer/Scripting/AI/AiScript.Routines.cs
@@ -132,7 +132,7 @@ namespace Melia.Zone.Scripting.AI
 		/// </summary>
 		/// <param name="skill"></param>
 		/// <returns></returns>
-		protected bool TryGetRandomSkill(out Skill skill)
+		protected virtual bool TryGetRandomSkill(out Skill skill)
 		{
 			skill = null;
 
@@ -151,19 +151,14 @@ namespace Melia.Zone.Scripting.AI
 
 			//var rndSkillId = mob.Data.Skills.Random().SkillId;
 
-			if (mob.ExtraSkill != null && RandomProvider.Get().Next(100) <= mob.ExtraSkillUseRate)
-			{
-				skill = mob.ExtraSkill;
-			}
-			else
-			{
-				var rndSkillId = mob.Data.Skills.First().SkillId;
+			
+			var rndSkillId = mob.Data.Skills.First().SkillId;
 
-				// Should we give monsters a skill manager? We might not
-				// actually need it, though we should probably at least
-				// cache the skills if we create them on demand.
-				skill = new Skill(this.Entity, rndSkillId, 1);
-			}
+			// Should we give monsters a skill manager? We might not
+			// actually need it, though we should probably at least
+			// cache the skills if we create them on demand.
+			skill = new Skill(this.Entity, rndSkillId, 1);
+			
 
 			return true;
 		}
@@ -174,7 +169,7 @@ namespace Melia.Zone.Scripting.AI
 		/// <param name="skill"></param>
 		/// <param name="target"></param>
 		/// <returns></returns>
-		protected IEnumerable UseSkill(Skill skill, ICombatEntity target)
+		protected virtual IEnumerable UseSkill(Skill skill, ICombatEntity target)
 		{
 			this.Entity.TurnTowards(target);
 			switch (skill.Data.UseType)

--- a/src/ZoneServer/Skills/Skill.cs
+++ b/src/ZoneServer/Skills/Skill.cs
@@ -129,7 +129,7 @@ namespace Melia.Zone.Skills
 		/// somewhere in the code. We'll need some more research to determine
 		/// what exactly makes a monster attack and when they apply.
 		/// </remarks>
-		public bool IsMonsterSkill => (int)this.Id >= 160000;
+		public bool IsMonsterSkill => (int)this.Id >= 60000;
 
 		/// <summary>
 		/// Returns true if this skill is a passive skill.
@@ -231,16 +231,14 @@ namespace Melia.Zone.Skills
 		/// <returns></returns>
 		public float GetAttackRange()
 		{
-			// Guessed, see GetSplashArea. Take a little off the top,
-			// so entities actually have to get into the splash area.
-			//return this.Properties.GetFloat(PropertyName.SplHeight);
+			// For monster skills, the MaxR value appears to correspond to their
+			// range, but for player skills, this value is almost always 100,
+			// regardless of their hitbox size.  Is there any reliable method
+			// of calculating the range for a player skill?
 
-			// After testing splash height, it seems unlikely that that's
-			// the way to get the min distance. It seems a little counter-
-			// intuitive, but let's try MaxR, which seems to have rather
-			// fitting values for this purpose.
-
-			// TODO: find a way to make this work for player skills
+			// TODO: Remove these placeholders once a method of calculating the
+			// range can be found.  Currently just using the length of the skill's
+			// hitbox -5f.
 			if (this.Id == SkillId.Highlander_CrossCut)
 				return 40f;
 			if (this.Id == SkillId.Wizard_EarthQuake)

--- a/src/ZoneServer/Skills/Skill.cs
+++ b/src/ZoneServer/Skills/Skill.cs
@@ -122,6 +122,16 @@ namespace Melia.Zone.Skills
 		public bool IsNormalAttack => (int)this.Id <= 1000;
 
 		/// <summary>
+		/// Returns true if the skill is a monster skill
+		/// </summary>
+		/// <remarks>
+		/// This property is a temporary measure to not do this check randomly
+		/// somewhere in the code. We'll need some more research to determine
+		/// what exactly makes a monster attack and when they apply.
+		/// </remarks>
+		public bool IsMonsterSkill => (int)this.Id >= 160000;
+
+		/// <summary>
 		/// Returns true if this skill is a passive skill.
 		/// </summary>
 		public bool IsPassive => this.Data.ActivationType == SkillActivationType.PassiveSkill;
@@ -229,6 +239,13 @@ namespace Melia.Zone.Skills
 			// the way to get the min distance. It seems a little counter-
 			// intuitive, but let's try MaxR, which seems to have rather
 			// fitting values for this purpose.
+
+			// TODO: find a way to make this work for player skills
+			if (this.Id == SkillId.Highlander_CrossCut)
+				return 40f;
+			if (this.Id == SkillId.Wizard_EarthQuake)
+				return 45f;
+
 			return this.Properties.GetFloat(PropertyName.MaxR);
 		}
 

--- a/src/ZoneServer/World/Actors/Monsters/Mob.cs
+++ b/src/ZoneServer/World/Actors/Monsters/Mob.cs
@@ -17,6 +17,7 @@ using Yggdrasil.Scheduling;
 using Yggdrasil.Util;
 using Melia.Zone.Buffs;
 using Melia.Zone.Buffs.Handlers;
+using Melia.Zone.Skills;
 
 namespace Melia.Zone.World.Actors.Monsters
 {
@@ -217,6 +218,28 @@ namespace Melia.Zone.World.Actors.Monsters
 		/// Return the monster's temporary variables.
 		/// </summary>
 		public Variables Vars { get; } = new Variables();
+
+		/// <summary>
+		/// Return the mob's extra skill
+		/// </summary>
+		public Skill ExtraSkill { get; set; }
+
+		/// <summary>
+		/// Return the mob's extra skill use rate
+		/// </summary>
+		public int ExtraSkillUseRate { get; set; }
+
+		/// <summary>
+		/// Return if the Mob is a Blue Orb
+		/// This should eventually move to a Minion Type
+		/// </summary>
+		public bool IsBlueOrb { get; set; }
+
+		/// <summary>
+		/// Return if the Mob is a Red Orb
+		/// This should eventually move to a Minion Type
+		/// </summary>
+		public bool IsRedOrb { get; set; }
 
 		/// <summary>
 		/// Creates new NPC.

--- a/src/ZoneServer/World/Actors/Monsters/MonsterProperties.cs
+++ b/src/ZoneServer/World/Actors/Monsters/MonsterProperties.cs
@@ -103,10 +103,11 @@ namespace Melia.Zone.World.Actors.Monsters
 		}
 
 		/// <summary>
-		/// Scales the monster's stats based on a target level
+		/// Scales the monster's stats based on a target level, mostly for
+		/// use with pets.
 		/// </summary>
 		/// <remarks>
-		/// The monster's stats change by 2% per level
+		/// Currently using 2% per level as an approximate level of power.
 		/// </remarks>
 		public void ScaleStatsToLevel(int targetLevel)
 		{
@@ -121,11 +122,16 @@ namespace Melia.Zone.World.Actors.Monsters
 			var levelDifferential = Math.Abs(targetLevel - currentLevel);
 			var statMultiplier = 1f;
 
+			// We use the power function so the stat boosts are boosted cumulatively, this
+			// makes a big difference when the level differential is high.
 			if (targetLevel > currentLevel)
 				statMultiplier = (float)Math.Pow(1.02f, levelDifferential);
 
 			if (targetLevel < currentLevel)
 				statMultiplier = (float)Math.Pow(0.98f, levelDifferential);
+
+			// Need to subtract 1 because the modify method affects stats additively.
+			statMultiplier--;
 
 			this.SetFloat(PropertyName.Level, targetLevel);
 			this.Modify(PropertyName.MHP_BM, mobData.Hp * statMultiplier);
@@ -143,13 +149,13 @@ namespace Melia.Zone.World.Actors.Monsters
 			this.Modify(PropertyName.BLK_BREAK_BM, mobData.BlockBreakRate * statMultiplier);			
 		}
 
-	/// <summary>
-	/// Creates a new calculated float property that uses the given
-	/// function.
-	/// </summary>
-	/// <param name="propertyName"></param>
-	/// <param name="calcFuncName"></param>
-	private void Create(string propertyName, string calcFuncName)
+		/// <summary>
+		/// Creates a new calculated float property that uses the given
+		/// function.
+		/// </summary>
+		/// <param name="propertyName"></param>
+		/// <param name="calcFuncName"></param>
+		private void Create(string propertyName, string calcFuncName)
 		{
 			this.Create(new CFloatProperty(propertyName, () => this.CalculateProperty(calcFuncName)));
 		}

--- a/system/conf/world/summons.conf
+++ b/system/conf/world/summons.conf
@@ -4,22 +4,37 @@
 
 // If enabled, monsters summoned via blue orbs will follow their summoners
 // through warps and persist through relogs.
+// This also applies to red orbs if the red orb pet system is on
 blue_orb_follow_warp: no
 
-// If enabled, monsters summoned via blue orbs will last indefinitely
-// and blue orbs aren't used up when summoning monsters.
+// If enabled, blue orb monsters last indefinitely.  This also applies to
+// red orb monsters if the pet system is on
+blue_orb_unlimited_duration: no
+
+// If enabled, blue orb monsters have their stats scaled up to match the
+// summoner's level.  Also applies to red orb monsters if the pet system is on
+blue_orb_scale_to_level: no
+
+// If enabled, monsters summoned via blue orbs also grant a buff,
+// and their orbs aren't used up when summoning them
 blue_orb_pet_system: no
+
+// If enabled, monsters summoned via red orbs also become friendly monsters,
+// and they have access to an extra skill
+red_orb_pet_system: no
 
 // Rate for red orb monsters to be jackpot monsters, in percent.
 // ie, 500 = 500% = 5x base chance to be a jackpot
 // This is multiplicative with the base chance for monsters to be jackpots
 // in raremonsters.conf
+// this doesn't apply if the red orb pet system is turned on
 red_orb_jackpot_rate: 100
 
 // Rate for red orb monsters to be elites, in percent.
 // ie, 500 = 500% = 5x base chance to be an elite
 // This is multiplicative with the base chance for monsters to be elites
 // in raremonsters.conf
+// this doesn't apply if the red orb pet system is turned on
 red_orb_elite_rate: 100
 
 include "/user/conf/world/summons.conf"

--- a/system/scripts/zone/core/calc_monster.cs
+++ b/system/scripts/zone/core/calc_monster.cs
@@ -9,6 +9,7 @@ using Melia.Shared.Game.Const;
 using Melia.Zone.Scripting;
 using Melia.Zone.World.Actors.CombatEntities.Components;
 using Melia.Zone.World.Actors.Monsters;
+using Yggdrasil.Logging;
 
 public class MonsterCalculationsFunctionsScript : GeneralScript
 {
@@ -20,10 +21,11 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 	[ScriptableFunction]
 	public float SCR_Get_MON_MHP(Mob monster)
 	{
-		if (monster.Properties.Overrides.TryGetFloat(PropertyName.MHP, out var fixValue))
-			return fixValue;
+		var baseValue = (float)monster.Data.Hp;
 
-		var baseValue = monster.Data.Hp;
+		if (monster.Properties.Overrides.TryGetFloat(PropertyName.MHP, out var fixValue))
+			baseValue = fixValue;
+
 		var byBuff = monster.Properties.GetFloat(PropertyName.MHP_BM);
 
 		return baseValue + byBuff;
@@ -37,10 +39,10 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 	[ScriptableFunction]
 	public float SCR_Get_MON_MSP(Mob monster)
 	{
+		var baseValue = (float)monster.Data.Sp;
 		if (monster.Properties.Overrides.TryGetFloat(PropertyName.MSP, out var fixValue))
-			return fixValue;
+			baseValue = fixValue;
 
-		var baseValue = monster.Data.Hp;
 		var byBuff = monster.Properties.GetFloat(PropertyName.MSP_BM);
 
 		return baseValue + byBuff;
@@ -53,13 +55,13 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 	/// <returns></returns>
 	[ScriptableFunction]
 	public float SCR_Get_MON_MINPATK(Mob monster)
-	{
-		if (monster.Properties.Overrides.TryGetFloat(PropertyName.MINPATK, out var fixValue))
-			return fixValue;
-
+	{		
 		var properties = monster.Properties;
 
 		var baseValue = (float)monster.Data.PhysicalAttackMin;
+		if (monster.Properties.Overrides.TryGetFloat(PropertyName.MINPATK, out var fixValue))
+			baseValue = fixValue;
+
 		var value = baseValue;
 
 		var byBuffs = 0f;
@@ -84,12 +86,12 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 	[ScriptableFunction]
 	public float SCR_Get_MON_MAXPATK(Mob monster)
 	{
-		if (monster.Properties.Overrides.TryGetFloat(PropertyName.MAXPATK, out var fixValue))
-			return fixValue;
-
 		var properties = monster.Properties;
 
 		var baseValue = (float)monster.Data.PhysicalAttackMax;
+		if (monster.Properties.Overrides.TryGetFloat(PropertyName.MAXPATK, out var fixValue))
+			baseValue = fixValue;
+
 		var value = baseValue;
 
 		var byBuffs = 0f;
@@ -114,12 +116,12 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 	[ScriptableFunction]
 	public float SCR_Get_MON_MINMATK(Mob monster)
 	{
-		if (monster.Properties.Overrides.TryGetFloat(PropertyName.MINMATK, out var fixValue))
-			return fixValue;
-
 		var properties = monster.Properties;
 
 		var baseValue = (float)monster.Data.MagicalAttackMin;
+		if (monster.Properties.Overrides.TryGetFloat(PropertyName.MINMATK, out var fixValue))
+			baseValue = fixValue;
+
 		var value = baseValue;
 
 		var byBuffs = 0f;
@@ -144,12 +146,12 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 	[ScriptableFunction]
 	public float SCR_Get_MON_MAXMATK(Mob monster)
 	{
-		if (monster.Properties.Overrides.TryGetFloat(PropertyName.MAXMATK, out var fixValue))
-			return fixValue;
-
 		var properties = monster.Properties;
 
 		var baseValue = (float)monster.Data.MagicalAttackMax;
+		if (monster.Properties.Overrides.TryGetFloat(PropertyName.MAXMATK, out var fixValue))
+			baseValue = fixValue;
+
 		var value = baseValue;
 
 		var byBuffs = 0f;
@@ -174,12 +176,12 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 	[ScriptableFunction]
 	public float SCR_Get_MON_DEF(Mob monster)
 	{
-		if (monster.Properties.Overrides.TryGetFloat(PropertyName.DEF, out var fixValue))
-			return fixValue;
-
 		var properties = monster.Properties;
 
 		var baseValue = (float)monster.Data.PhysicalDefense;
+		if (monster.Properties.Overrides.TryGetFloat(PropertyName.DEF, out var fixValue))
+			baseValue = fixValue;
+
 		var value = baseValue;
 
 		var byBuffs = properties.GetFloat(PropertyName.DEF_BM);
@@ -201,12 +203,12 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 	[ScriptableFunction]
 	public float SCR_Get_MON_MDEF(Mob monster)
 	{
-		if (monster.Properties.Overrides.TryGetFloat(PropertyName.MDEF, out var fixValue))
-			return fixValue;
-
 		var properties = monster.Properties;
 
 		var baseValue = (float)monster.Data.MagicalDefense;
+		if (monster.Properties.Overrides.TryGetFloat(PropertyName.MDEF, out var fixValue))
+			baseValue = fixValue;
+
 		var value = baseValue;
 
 		var byBuffs = properties.GetFloat(PropertyName.MDEF_BM);
@@ -263,12 +265,12 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 	[ScriptableFunction]
 	public float SCR_Get_MON_DR(Mob monster)
 	{
-		if (monster.Properties.Overrides.TryGetFloat(PropertyName.DR, out var fixValue))
-			return fixValue;
-
 		var properties = monster.Properties;
 
 		var baseValue = (float)monster.Data.DodgeRate;
+		if (monster.Properties.Overrides.TryGetFloat(PropertyName.DR, out var fixValue))
+			baseValue = fixValue;
+
 		var byBuffs = properties.GetFloat(PropertyName.DR_BM);
 
 		return baseValue + byBuffs;
@@ -282,12 +284,12 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 	[ScriptableFunction]
 	public float SCR_Get_MON_HR(Mob monster)
 	{
-		if (monster.Properties.Overrides.TryGetFloat(PropertyName.HR, out var fixValue))
-			return fixValue;
-
 		var properties = monster.Properties;
 
 		var baseValue = (float)monster.Data.HitRate;
+		if (monster.Properties.Overrides.TryGetFloat(PropertyName.HR, out var fixValue))
+			baseValue = fixValue;
+
 		var byBuffs = properties.GetFloat(PropertyName.HR_BM);
 
 		return baseValue + byBuffs;
@@ -349,10 +351,12 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 	[ScriptableFunction]
 	public float SCR_Get_MON_CRTHR(Mob monster)
 	{
-		if (monster.Properties.Overrides.TryGetFloat(PropertyName.CRTHR, out var fixValue))
-			return fixValue;
+		var baseValue = (float)monster.Data.CritHitRate;
 
-		var value = (float)monster.Data.CritHitRate;
+		if (monster.Properties.Overrides.TryGetFloat(PropertyName.CRTHR, out var fixValue))
+			baseValue = fixValue;
+
+		var value = baseValue;
 
 		var byBuffs = 0f;
 		byBuffs += monster.Properties.GetFloat(PropertyName.CRTHR_BM, 0);
@@ -374,10 +378,12 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 	[ScriptableFunction]
 	public float SCR_Get_MON_CRTDR(Mob monster)
 	{
-		if (monster.Properties.Overrides.TryGetFloat(PropertyName.CRTDR, out var fixValue))
-			return fixValue;
+		var baseValue = (float)monster.Data.CritDodgeRate;
 
-		var value = (float)monster.Data.CritDodgeRate;
+		if (monster.Properties.Overrides.TryGetFloat(PropertyName.CRTDR, out var fixValue))
+			baseValue = fixValue;
+
+		var value = baseValue;
 
 		var byBuffs = 0f;
 		byBuffs += monster.Properties.GetFloat(PropertyName.CRTDR_BM, 0);
@@ -406,10 +412,10 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 	[ScriptableFunction]
 	public float SCR_Get_MON_CRTATK(Mob monster)
 	{
-		if (monster.Properties.Overrides.TryGetFloat(PropertyName.CRTATK, out var fixValue))
-			return fixValue;
-
 		var baseValue = (float)monster.Data.CritAttack;
+		if (monster.Properties.Overrides.TryGetFloat(PropertyName.CRTATK, out var fixValue))
+			baseValue = fixValue;
+
 		var byBuffs = monster.Properties.GetFloat(PropertyName.CRTATK_BM, 0);
 
 		var value = baseValue + byBuffs;
@@ -425,12 +431,12 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 	[ScriptableFunction]
 	public float SCR_Get_MON_BLK(Mob monster)
 	{
-		if (monster.Properties.Overrides.TryGetFloat(PropertyName.BLK, out var fixValue))
-			return fixValue;
-
 		var properties = monster.Properties;
 
 		var baseValue = (float)monster.Data.BlockRate;
+		if (monster.Properties.Overrides.TryGetFloat(PropertyName.BLK, out var fixValue))
+			baseValue = fixValue;
+
 		var byBuffs = properties.GetFloat(PropertyName.BLK_BM);
 
 		var value = baseValue + byBuffs;
@@ -446,12 +452,12 @@ public class MonsterCalculationsFunctionsScript : GeneralScript
 	[ScriptableFunction]
 	public float SCR_Get_MON_BLK_BREAK(Mob monster)
 	{
-		if (monster.Properties.Overrides.TryGetFloat(PropertyName.BLK_BREAK, out var fixValue))
-			return fixValue;
-
 		var properties = monster.Properties;
 
 		var baseValue = (float)monster.Data.BlockBreakRate;
+		if (monster.Properties.Overrides.TryGetFloat(PropertyName.BLK_BREAK, out var fixValue))
+			baseValue = fixValue;
+
 		var byBuffs = properties.GetFloat(PropertyName.BLK_BREAK_BM);
 
 		var value = baseValue + byBuffs;


### PR DESCRIPTION
Increases the Orb Pet system to allow you to turn Red Orbs into a second type of pet, and also enhances Blue Orbs.  The idea is that Blue Orb monsters give you a passive buff, while Red Orb monsters can use an additional active skill, and you can have one of each.  There are a lot of new customization options related to this functionality, including one that lets you scale the orb pets to the player's level, so they don't become uselessly weak once you level up a bit.

In the future, the data relating to what buff or what active skill these monsters have would be stored in its own database.  There's really nothing stopping that from being done now beyond the fact that I want to get this approved before I add hundreds of entries.

One thing to note is that this PR also fixes a pre-existing bug where monster stat overrides would prevent buffs from being applied, which is bad because monster stats are always overridden by spawners.