### PR TITLE
Fix buying same nonstackable item twice

### DIFF
--- a/src/ZoneServer/Network/PacketHandler.cs
+++ b/src/ZoneServer/Network/PacketHandler.cs
@@ -1591,7 +1591,10 @@ namespace Melia.Zone.Network
 				var productId = packet.GetInt();
 				var amount = packet.GetInt();
 
-				purchases[productId] = amount;
+				if (!purchases.ContainsKey(productId))
+					purchases[productId] = amount;
+				else
+					purchases[productId] += amount;
 			}
 
 			var character = conn.SelectedCharacter;


### PR DESCRIPTION
This PR fixes attempting to buy the same item twice.

Current behaviour: If you add two non-stackable items to your shop list, only one goes to your inventory.

After PR behaviour: You add two non-stackable items to your shop list, both go to your inventory.

Thanks to @SalmanTKhan for implementation.