### PR TITLE
Fix for threat calculation

### DIFF
--- a/src/ZoneServer/Scripting/AI/AiScript.cs
+++ b/src/ZoneServer/Scripting/AI/AiScript.cs
@@ -235,6 +235,14 @@ namespace Melia.Zone.Scripting.AI
 			if (entity.Components.Get<BuffComponent>().Has(BuffId.Liberate_Buff))
 				amount *= 5;
 
+			if (amount > _minAggroHateLevel)
+			{
+				var pastOverHate = amount - _minAggroHateLevel;
+				amount -= pastOverHate;
+				pastOverHate *= _overHateRate;
+				amount += pastOverHate;
+			}
+
 			_hateLevels[handle] += amount;
 
 			//Log.Debug("Monster {0} hate level for {1} is now {2}.", this.Entity, handle, _hateLevels[handle]);


### PR DESCRIPTION
In AiScript.cs, the hate given per hit can be exploited if user has Liberate buff and monster has less than _minAggroHateLevel amount of hate towards the player.

If the player with Liberate hits a monster with zero hate, they will immediately build 500 hate towards them. If they hit a monster with 100 or more hate towards them, there is no issue as that hate value will be multiplied by _overHateRate.

This PR addresses this issue by adding a simple check at the end of IncreaseHate() and multiplying any threat amount past the limit by the _overHateRate.