### PR TITLE
Basic monster attack cancelling

### DIFF
--- a/src/ZoneServer/Network/Send.cs
+++ b/src/ZoneServer/Network/Send.cs
@@ -212,18 +212,18 @@ namespace Melia.Zone.Network
 		}
 
 		/// <summary>
-		/// Exact purpose unknown, but it stops the animation of Multishot.
+		/// Cancels ongoing skill animations.  Used by Archer_Multishot and monster skills.
 		/// </summary>
 		/// <param name="character"></param>
-		public static void ZC_SKILL_DISABLE(Character character)
+		public static void ZC_SKILL_DISABLE(ICombatEntity entity)
 		{
 			var packet = new Packet(Op.ZC_SKILL_DISABLE);
 
-			packet.PutInt(character.Handle);
+			packet.PutInt(entity.Handle);
 			packet.PutByte(0);
 			packet.PutInt(0); // very random number?
 
-			character.Connection.Send(packet);
+			entity.Map.Broadcast(packet);
 		}
 
 		/// <summary>

--- a/src/ZoneServer/Skills/Combat/SkillHitInfo.cs
+++ b/src/ZoneServer/Skills/Combat/SkillHitInfo.cs
@@ -103,6 +103,10 @@ namespace Melia.Zone.Skills.Combat
 			target.Position = this.KnockBackInfo.ToPosition;
 
 			target.AddState(StateType.KnockedBack, this.KnockBackInfo.Time);
+
+			// Currently we consider knockdowns to also be knockbacks
+			// so any knockback-specific functionality also applies to them.
+			// Note that some skills check for knockdowns specifically.
 			if (this.HitInfo.Type == HitType.KnockDown)
 				target.AddState(StateType.KnockedDown, this.KnockBackInfo.Time);
 		}

--- a/src/ZoneServer/Skills/Combat/SkillHitInfo.cs
+++ b/src/ZoneServer/Skills/Combat/SkillHitInfo.cs
@@ -99,6 +99,13 @@ namespace Melia.Zone.Skills.Combat
 			if (this.KnockBackInfo == null)
 				throw new InvalidOperationException("Knock back info is not set.");
 
+			// Cannot suffer additional knockback while knocked down
+			if (target.IsStateActive(StateType.KnockedDown))
+			{
+				this.KnockBackInfo = null;
+				return;
+			}
+
 			this.HitInfo.Type = this.KnockBackInfo.HitType;
 			target.Position = this.KnockBackInfo.ToPosition;
 

--- a/src/ZoneServer/Skills/Combat/SkillHitInfo.cs
+++ b/src/ZoneServer/Skills/Combat/SkillHitInfo.cs
@@ -99,10 +99,12 @@ namespace Melia.Zone.Skills.Combat
 			if (this.KnockBackInfo == null)
 				throw new InvalidOperationException("Knock back info is not set.");
 
-			this.HitInfo.Type = this.Skill.Data.KnockDownHitType;
+			this.HitInfo.Type = this.KnockBackInfo.HitType;
 			target.Position = this.KnockBackInfo.ToPosition;
 
 			target.AddState(StateType.KnockedBack, this.KnockBackInfo.Time);
+			if (this.HitInfo.Type == HitType.KnockDown)
+				target.AddState(StateType.KnockedDown, this.KnockBackInfo.Time);
 		}
 	}
 }

--- a/src/ZoneServer/Skills/Combat/SkillHitInfo.cs
+++ b/src/ZoneServer/Skills/Combat/SkillHitInfo.cs
@@ -97,14 +97,7 @@ namespace Melia.Zone.Skills.Combat
 		public void ApplyKnockBack(ICombatEntity target)
 		{
 			if (this.KnockBackInfo == null)
-				throw new InvalidOperationException("Knock back info is not set.");
-
-			// Cannot suffer additional knockback while knocked down
-			if (target.IsStateActive(StateType.KnockedDown))
-			{
-				this.KnockBackInfo = null;
-				return;
-			}
+				throw new InvalidOperationException("Knock back info is not set.");			
 
 			this.HitInfo.Type = this.KnockBackInfo.HitType;
 			target.Position = this.KnockBackInfo.ToPosition;

--- a/src/ZoneServer/Skills/Handlers/Base/SimpleMonsterAttackSkill.cs
+++ b/src/ZoneServer/Skills/Handlers/Base/SimpleMonsterAttackSkill.cs
@@ -62,8 +62,13 @@ namespace Melia.Zone.Skills.Handlers.Base
 				await Task.Delay(hitDelay);
 
 			// Check if attacker is still able to fight after the delay
+			// This is not foolproof.  If a lock is applied and removed during the delay
+			// this should still cancel the skill but it won't with this implementation 
 			if (!caster.CanFight())
+			{
+				Send.ZC_SKILL_DISABLE(caster);
 				return;
+			}
 
 			var targets = caster.Map.GetAttackableEntitiesIn(caster, splashArea);
 			var hits = new List<SkillHitInfo>();

--- a/src/ZoneServer/Skills/Handlers/Swordsmen/Doppelsoeldner/Doppelsoeldner_Punish.cs
+++ b/src/ZoneServer/Skills/Handlers/Swordsmen/Doppelsoeldner/Doppelsoeldner_Punish.cs
@@ -98,7 +98,7 @@ namespace Melia.Zone.Skills.Handlers.Swordsmen.Doppelsoeldner
 			{
 				var modifier = new SkillModifier();
 
-				if (target.IsStateActive(StateType.KnockedBack))
+				if (target.IsStateActive(StateType.KnockedDown))
 					modifier.DamageMultiplier = KnockdownMultiplier;
 
 				if (caster.TryGetBuff(BuffId.DeedsOfValor, out var dovBuff))

--- a/src/ZoneServer/World/Actors/Characters/Character.cs
+++ b/src/ZoneServer/World/Actors/Characters/Character.cs
@@ -1308,6 +1308,9 @@ namespace Melia.Zone.World.Actors.Characters
 			if (this.IsDead)
 				return false;
 
+			if (this.IsLocked(LockType.Attack))
+				return false;
+
 			return true;
 		}
 

--- a/src/ZoneServer/World/Actors/Components/StateLockComponent.cs
+++ b/src/ZoneServer/World/Actors/Components/StateLockComponent.cs
@@ -50,6 +50,7 @@ namespace Melia.Zone.World.Actors.Components
 
 			this.RegisterState(new(StateType.Stunned, [LockType.Movement, LockType.Attack]));
 			this.RegisterState(new(StateType.KnockedBack, [LockType.Movement, LockType.Attack]));
+			this.RegisterState(new(StateType.KnockedDown, [LockType.Movement, LockType.Attack]));
 			this.RegisterState(new(StateType.Held, [LockType.Movement]));
 		}
 
@@ -306,6 +307,7 @@ namespace Melia.Zone.World.Actors.Components
 	{
 		public const string Stunned = "Stunned";
 		public const string KnockedBack = "KnockedBack";
+		public const string KnockedDown = "KnockedDown";
 		public const string Held = "Held";
 	}
 

--- a/src/ZoneServer/World/Actors/Monsters/Mob.cs
+++ b/src/ZoneServer/World/Actors/Monsters/Mob.cs
@@ -716,6 +716,9 @@ namespace Melia.Zone.World.Actors.Monsters
 			if (this.IsDead)
 				return false;
 
+			if (this.IsLocked(LockType.Attack))
+				return false;
+
 			return true;
 		}
 


### PR DESCRIPTION
Adds attack cancelling for monsters based on locks.  Nothing for players yet.

Also adds the Knockdown locktype for Doppelsoldner_Punish.