### PR TITLE
Minor fix to skill tags

### DIFF
--- a/src/ZoneServer/Skills/Skill.cs
+++ b/src/ZoneServer/Skills/Skill.cs
@@ -113,16 +113,16 @@ namespace Melia.Zone.Skills
 		/// <summary>
 		/// Returns true if the skill is a normal attack.
 		/// </summary>
+		/// <remarks>
 		/// This property is a temporary measure to not do this check randomly
 		/// somewhere in the code. We'll need some more research to determine
 		/// what exactly makes a normal attack and when they apply. Especially
 		/// because it seems like this might differ based on your stance.
-		/// 
 		/// Update: We used to check id ranges here, but we found the "keywords"
-		/// or tags on the skill data by now, which include the "NormalAttack"
+		/// or tags on the skill data by now, which include the "NormalSkill"
 		/// tag. We'll assume that to be the way to determine normal attacks for
 		/// now.
-		public bool IsNormalAttack => this.Data.Tags.Has("NormalAttack");
+		public bool IsNormalAttack => this.Data.Tags.Has("NormalSkill");
 
 		/// <summary>
 		/// Returns true if the skill is a monster skill

--- a/src/ZoneServer/Skills/Skill.cs
+++ b/src/ZoneServer/Skills/Skill.cs
@@ -122,7 +122,7 @@ namespace Melia.Zone.Skills
 		/// or tags on the skill data by now, which include the "NormalSkill"
 		/// tag. We'll assume that to be the way to determine normal attacks for
 		/// now.
-		public bool IsNormalAttack => this.Data.Tags.Has("NormalSkill");
+		public bool IsNormalAttack => this.Data.Tags.Has(SkillTag.NormalSkill);
 
 		/// <summary>
 		/// Returns true if the skill is a monster skill


### PR DESCRIPTION
Super small fix to skill tags, the correct tag is "NormalSkill", not "NormalAttack".