### PR TITLE
Fix custom shops buying multiple items

### DIFF
--- a/src/ZoneServer/Network/PacketHandler.cs
+++ b/src/ZoneServer/Network/PacketHandler.cs
@@ -1673,7 +1673,7 @@ namespace Melia.Zone.Network
 				}
 				else
 				{
-					totalCost += (int)productData.PriceMultiplier * productData.Amount;
+					totalCost += (int)productData.PriceMultiplier * amount;
 				}
 
 				purchaseList.Add(new Tuple<ItemData, int>(itemData, amount));


### PR DESCRIPTION
Fixes buying multiple items when using custom shops.

`productData.Amount` is how many items are being sold
`amount` is the actual amount of item stack player is trying to buy